### PR TITLE
#ISSUE4 - [FEAT] - Raw_Materials 채굴 기능 구현

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,30 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from dotenv import load_dotenv
+
+# .env 로드
+load_dotenv()
+
+# 환경변수 읽기
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+if not DATABASE_URL:
+    raise ValueError("DATABASE_URL 환경변수가 설정되지 않았습니다. .env 파일을 확인하세요.")
+
+# PostgreSQL 엔진 생성
+engine = create_engine(DATABASE_URL)
+
+# DB 세션 생성기
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# 모델 Base 클래스
+Base = declarative_base()
+
+# FastAPI 의존성 주입 함수
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,19 @@
 from fastapi import FastAPI
-from backend.routers import example
+from contextlib import asynccontextmanager
 
-app = FastAPI()
+from backend.database import Base, engine, SessionLocal
+from backend.utils.seed import seed_raw_materials
+from backend.models import gift
 
-app.include_router(example.router)
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    Base.metadata.create_all(bind=engine)
+    seed_raw_materials()
+    yield 
+    print("Shutting down...")
 
-@app.get("/")
-def home():
-    return {"message": "DB-SCDMS Backend is running!"}
+app = FastAPI(lifespan=lifespan)
+
+# --- Routers ---
+from backend.routers import gift
+app.include_router(gift.router)

--- a/backend/models/gift.py
+++ b/backend/models/gift.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String
+from backend.database import Base
+
+class RawMaterial(Base):
+    __tablename__ = "Raw_Materials"
+
+    material_id = Column(Integer, primary_key=True, index=True)
+    material_name = Column(String, unique=True, nullable=False)
+    stock_quantity = Column(Integer, default=0)

--- a/backend/routers/gift.py
+++ b/backend/routers/gift.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models.gift import RawMaterial
+from backend.schemas.gift import MaterialUpdate
+
+router = APIRouter(prefix="/gift", tags=["Gift"])
+
+@router.post("/materials/mine")
+def mine_material(data: MaterialUpdate, db: Session = Depends(get_db)):
+    
+    # 음수 요청 자체 차단
+    if data.amount < 0:
+        raise HTTPException(
+            status_code=400,
+            detail="채굴량(amount)은 음수일 수 없습니다."
+        )
+
+    material = db.query(RawMaterial).filter_by(material_id=data.material_id).first()
+
+    if not material:
+        raise HTTPException(status_code=404, detail="해당 재료가 존재하지 않습니다.")
+
+    # 재고 음수 방지
+    new_quantity = material.stock_quantity + data.amount
+    if new_quantity < 0:
+        raise HTTPException(
+            status_code=400,
+            detail=f"재고 부족으로 인해 재고가 음수가 될 수 없습니다. (현재 재고: {material.stock_quantity})"
+        )
+
+    # 정상 업데이트
+    material.stock_quantity = new_quantity
+    db.commit()
+    db.refresh(material)
+
+    return {
+        "message": "재료 재고 업데이트 완료",
+        "material_id": material.material_id,
+        "stock_quantity": material.stock_quantity
+    }
+

--- a/backend/schemas/gift.py
+++ b/backend/schemas/gift.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class MaterialUpdate(BaseModel):
+    material_id: int
+    amount: int

--- a/backend/utils/seed.py
+++ b/backend/utils/seed.py
@@ -1,0 +1,25 @@
+from backend.database import SessionLocal
+from backend.models.gift import RawMaterial
+
+def seed_raw_materials():
+    db = SessionLocal()
+
+    default_materials = [
+        (1, "유니콘의털"),
+        (2, "별가루"),
+        (3, "드래곤비늘"),
+        (4, "천사의눈물"),
+        (5, "태양조각"),
+    ]
+
+    for mid, name in default_materials:
+        exists = db.query(RawMaterial).filter_by(material_id=mid).first()
+        if not exists:
+            db.add(RawMaterial(
+                material_id=mid,
+                material_name=name,
+                stock_quantity=0
+            ))
+
+    db.commit()
+    db.close()


### PR DESCRIPTION
## 개요
* GiftElf가 사용할 원자재 채굴 기능(Raw_Materials Mining)을 FastAPI 기반 백엔드에 구현했습니다.
* `/gift/materials/mine` API를 통해 특정 MaterialID의 재고를 증가시킬 수 있습니다.
* 잘못된 요청 또는 시스템 오류로 인해 재고가 음수가 되는 문제를 방지하도록 검증 로직을 추가하였습니다.
* Swagger(`/docs`) 및 실제 PostgreSQL DB 조회로 재고 증가 로직의 정상 작동을 확인했습니다.

## 설명

### 1) Raw_Materials 모델 생성

* SQLAlchemy 모델(`RawMaterial`) 생성
* 필드: `material_id`, `material_name`, `stock_quantity`

### 2) MaterialUpdate 스키마 생성

* 채굴 API에서 사용할 입력 데이터 구조 정의
* `material_id`, `amount` 필드 포함

### 3) 채굴 API 구현 (`POST /gift/materials/mine`)

* GiftElf가 특정 재료의 재고를 증가시키는 기능 구현
* 성공 시 업데이트된 재고 반환

### 4) 재고 음수 방지 로직 추가

* `amount < 0` → 잘못된 요청으로 간주하고 400 에러 반환
* 계산된 재고(new_quantity)가 0 미만일 경우 업데이트 차단
* 생산/차감 기능 대비하여 선제적인 데이터 무결성 확보

### 5) 테스트 및 검증 완료

* Swagger에서 다양한 입력값으로 테스트
* PostgreSQL DB 연동 확인(SQLTools로 직접 조회)
* 재고 증가, 예외 처리 모두 정상 작동 확인

## API 동작 흐름

1. GiftElf가 `/gift/materials/mine` API 호출
2. 입력된 `material_id`로 재고 항목 조회
3. 음수 입력 또는 재고 음수 결과 여부 검증
4. 문제 없으면 `stock_quantity += amount`
5. DB commit → 업데이트된 재고값 반환

## 변경된 파일

* `backend/models/gift.py` → RawMaterial 모델 추가
* `backend/schemas/gift.py` → MaterialUpdate 스키마 추가
* `backend/routers/gift.py` → 채굴 API 구현
* `backend/utils/seed.py` → Raw_Materials 초기 더미 데이터 추가
* `backend/database.py`
* `backend/main.py`