### PR TITLE
#ISSUE10 - [FEAT] - 생산 Job 로그 및 재료 사용 내역 기록 기능 구현

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,5 +17,6 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # --- Routers ---
-from backend.routers import gift
+from backend.routers import gift, production
 app.include_router(gift.router)
+app.include_router(production.router)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,1 +1,1 @@
-from backend.models.gift import RawMaterial, FinishedGoods, GiftBOM
+from backend.models.gift import RawMaterial, FinishedGoods, GiftBOM, ProductionLog, ProductionUsage

--- a/backend/models/gift.py
+++ b/backend/models/gift.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, Integer, String, ForeignKey, UniqueConstraint, DateTime
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 from backend.database import Base
 
 class RawMaterial(Base):
@@ -11,6 +12,9 @@ class RawMaterial(Base):
     
     # GiftBOM에서 재료 역관계 참조 -> 재료가 어디 레시피에 쓰이는지 보고 싶을 때
     boms = relationship("GiftBOM", back_populates="input_material")
+    
+    # 이 재료가 어떤 생산 Job들에서 얼마나 사용됐는지 보고 싶을 때
+    production_usages = relationship("ProductionUsage", back_populates="material")
 
 class FinishedGoods(Base):
     __tablename__ = "Finished_Goods"
@@ -21,6 +25,9 @@ class FinishedGoods(Base):
     
     # GiftBOM에서 선물 역관계 참조 -> 선물을 만들 때 쓰이는 레시피가 보고 싶을 때
     boms = relationship("GiftBOM", back_populates="output_gift")
+    
+    # 생산 로그 목록을 보고 싶을 때
+    production_logs = relationship("ProductionLog", back_populates="gift")
     
 class GiftBOM(Base):
     __tablename__ = "gift_bom"
@@ -36,3 +43,61 @@ class GiftBOM(Base):
 
     output_gift = relationship("FinishedGoods", back_populates="boms")
     input_material = relationship("RawMaterial", back_populates="boms")
+    
+class ProductionLog(Base):
+    __tablename__ = "Production_Log"
+
+    job_id = Column(Integer, primary_key=True, index=True)
+
+    # 어떤 선물을 생산했는지
+    gift_id = Column(
+        Integer,
+        ForeignKey("Finished_Goods.gift_id"),
+        nullable=False,
+    )
+
+    # 몇 개를 생산했는지
+    quantity_produced = Column(Integer, nullable=False)
+
+    # 누가 생산했는지(스태프/사용자 ID)
+    produced_by_staff_id = Column(
+        Integer,
+        # ForeignKey("Staff.StaffID"),  # 나중에 Staff 테이블 생성했을 때 추가
+        nullable=False,
+    )
+
+    # 언제 생산했는지
+    timestamp = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),   # INSERT 시 자동으로 현재 시간
+        nullable=False,
+    )
+
+    gift = relationship("FinishedGoods", back_populates="production_logs")
+    # staff = relationship("Staff", back_populates="production_logs")  # 나중에 Staff 테이블 생성했을 때 추가
+    
+    # 이번 생산 Job에서 사용된 재료 목록
+    usages = relationship("ProductionUsage", back_populates="job")
+    
+class ProductionUsage(Base):
+    __tablename__ = "Production_Usage"
+
+    # 어떤 생산 Job에서
+    job_id = Column(
+        Integer,
+        ForeignKey("Production_Log.job_id"),
+        primary_key=True,
+    )
+
+    # 어떤 재료를
+    material_id = Column(
+        Integer,
+        ForeignKey("Raw_Materials.material_id"),
+        primary_key=True,
+    )
+
+    # 얼마나 사용했는지
+    quantity_used = Column(Integer, nullable=False)
+
+    job = relationship("ProductionLog", back_populates="usages")
+    material = relationship("RawMaterial", back_populates="production_usages")

--- a/backend/routers/gift.py
+++ b/backend/routers/gift.py
@@ -55,6 +55,17 @@ def get_all_gifts(db: Session = Depends(get_db)):
 # POST /gift/produce
 @router.post("/produce")
 def produce_item(data: ProduceRequest, db: Session = Depends(get_db)):
+    """
+    Gift_BOM 레시피를 사용해 선물 생산을 처리하는 간단 API
+
+    - 요청한 선물(gift_id)과 수량에 따라 필요한 재료량 계산
+    - 재료 재고가 부족하면 오류 반환
+    - 재료가 충분하면 Raw_Materials 재고 차감
+    - Finished_Goods 재고 증가
+
+    Production_Log / Production_Usage 기록은 남기지 않음 -> 실제 요정 UI에서 사용할 API는 /production/create
+    """
+
 
     # 선물 존재 여부 확인
     good = db.query(FinishedGoods).filter_by(gift_id=data.gift_id).first()
@@ -97,7 +108,7 @@ def produce_item(data: ProduceRequest, db: Session = Depends(get_db)):
         if material.stock_quantity < required:
             shortages.append({
                 "material_id": material.material_id,
-                "material_name": material.material_name,  # ← 여기!
+                "material_name": material.material_name,
                 "required": required,
                 "available": material.stock_quantity,
             })

--- a/backend/routers/production.py
+++ b/backend/routers/production.py
@@ -1,0 +1,145 @@
+# backend/routers/production.py
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models.gift import RawMaterial, FinishedGoods, GiftBOM, ProductionLog, ProductionUsage
+from backend.schemas.gift import ProductionCreateRequest
+from backend.utils.transactions import transactional_session
+
+router = APIRouter(prefix="/production", tags=["Production"])
+
+
+@router.post("/create")
+def create_production_job(data: ProductionCreateRequest, db: Session = Depends(get_db)):
+    """
+    생산 Job 1건을 생성하고
+    - 재료 재고 검증
+    - 재료 차감
+    - Finished_Goods 재고 증가
+    - Production_Log / Production_Usage 기록을 한 트랜잭션으로 처리
+    """
+
+    # ============================
+    # 사전 검증: 트랜잭션을 시작하기 전에 요청이 유효한지 미리 확인
+    # ============================
+
+    # 선물 존재 여부
+    gift = (
+        db.query(FinishedGoods)
+        .filter_by(gift_id=data.gift_id)
+        .first()
+    )
+    if not gift:
+        raise HTTPException(
+            status_code=404,
+            detail="해당 선물이 존재하지 않습니다.",
+        )
+
+    # 생산 수량 검증
+    if data.produced_quantity <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="생산 수량은 1 이상이어야 합니다.",
+        )
+
+    # 레시피 조회
+    boms = (
+        db.query(GiftBOM)
+        .filter_by(output_gift_id=data.gift_id)
+        .all()
+    )
+    if not boms:
+        raise HTTPException(
+            status_code=400,
+            detail="해당 선물에 대한 레시피가 등록되어 있지 않습니다.",
+        )
+
+    # 재료 부족 검사
+    shortages = []
+
+    for bom in boms:
+        material = (
+            db.query(RawMaterial)
+            .filter_by(material_id=bom.input_material_id)
+            .first()
+        )
+
+        if not material:
+            raise HTTPException(
+                status_code=400,
+                detail=f"레시피에 포함된 재료(ID: {bom.input_material_id})가 존재하지 않습니다.",
+            )
+
+        required = bom.quantity_required * data.produced_quantity
+
+        if material.stock_quantity < required:
+            shortages.append({
+                "material_id": material.material_id,
+                "material_name": material.material_name,
+                "required": required,
+                "available": material.stock_quantity,
+            })
+
+    # 재료 부족 시: 트랜잭션 들어가기 전에 바로 에러 반환 -> DB 변경 없음
+    if shortages:
+        names = ", ".join([s["material_name"] for s in shortages])
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": f"다음 재료 재고 부족으로 생산 Job을 생성할 수 없습니다: {names}",
+                "shortages": shortages,
+            },
+        )
+
+    # ==================================
+    # 트랜잭션 구간
+    # ==================================
+    with transactional_session(db):
+        # Raw_Materials 재고 차감
+        for bom in boms:
+            material = (
+                db.query(RawMaterial)
+                .filter_by(material_id=bom.input_material_id)
+                .first()
+            )
+            used = bom.quantity_required * data.produced_quantity
+            material.stock_quantity -= used
+
+        # Finished_Goods 재고 증가
+        gift.stock_quantity += data.produced_quantity
+
+        # Production_Log INSERT
+        log = ProductionLog(
+            gift_id=gift.gift_id,
+            quantity_produced=data.produced_quantity,
+            produced_by_staff_id=data.staff_id,
+        )
+        db.add(log)
+        db.flush()  # job_id 확보
+
+        # Production_Usage INSERT
+        for bom in boms:
+            used = bom.quantity_required * data.produced_quantity
+            usage = ProductionUsage(
+                job_id=log.job_id,
+                material_id=bom.input_material_id,
+                quantity_used=used,
+            )
+            db.add(usage)
+
+        # 여기서 예외가 없으면 contextmanager가 db.commit()
+        # 예외가 발생하면 db.rollback() 후 예외 재전파
+
+        db.refresh(log)
+        db.refresh(gift)
+
+    return {
+        "message": "생산 Job 생성 완료",
+        "job_id": log.job_id,
+        "gift_id": gift.gift_id,
+        "quantity_produced": log.quantity_produced,
+        "produced_by_staff_id": log.produced_by_staff_id,
+        "new_gift_stock": gift.stock_quantity,
+    }

--- a/backend/schemas/gift.py
+++ b/backend/schemas/gift.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import List, Optional
+from datetime import datetime
 
 # 원자재 채굴 요청 바디
 class MaterialUpdate(BaseModel):
@@ -25,6 +26,23 @@ class GiftRecipeItem(BaseModel):
     material_id: int
     material_name: str
     quantity_required: int
+
+    class Config:
+        orm_mode = True
+        
+# 생산 Job 생성 요청 바디
+class ProductionCreateRequest(BaseModel):
+    gift_id: int
+    produced_quantity: int
+    staff_id: int
+    
+# 생산 로그 응답 스키마
+class ProductionLogResponse(BaseModel):
+    job_id: int
+    gift_id: int
+    quantity_produced: int
+    produced_by_staff_id: int
+    timestamp: datetime
 
     class Config:
         orm_mode = True

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,1 @@
+from backend.utils.transactions import transactional_session

--- a/backend/utils/transactions.py
+++ b/backend/utils/transactions.py
@@ -1,0 +1,17 @@
+from contextlib import contextmanager
+from typing import Iterator
+from sqlalchemy.orm import Session
+
+
+@contextmanager
+def transactional_session(db: Session) -> Iterator[Session]:
+    """
+    - with 블록 안에서 예외가 없으면 COMMIT
+    - 예외가 발생하면 ROLLBACK 후 예외 다시 발생
+    """
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise


### PR DESCRIPTION
## 개요

기존에는 `/gift/produce` API를 통해 Gift_BOM 레시피 기반 생산 및 재고 증감까지만 처리했다.  
이번 PR에서는 **생산 Job 1건을 정식으로 기록하는 `/production/create` API**를 추가하고

- Raw_Materials 재고 차감
- Finished_Goods 재고 증가
- Production_Log / Production_Usage 기록
- 트랜잭션 기반 COMMIT / ROLLBACK 처리

를 한 번에 수행하는 **생산 시스템 v2**를 구현하였다.

## 주요 변경 사항

1. **Production_Log 모델 추가**
   - 테이블: `Production_Log`
   - 컬럼
     - `job_id` (PK)
     - `gift_id` (FK → Finished_Goods.gift_id)
     - `quantity_produced`
     - `produced_by_staff_id`
     - `timestamp` (생산 시각, 기본값 `NOW()`)
   - 관계
     - `FinishedGoods.production_logs` ↔ `ProductionLog.gift`

2. **Production_Usage 모델 추가**
   - 테이블: `Production_Usage`
   - 컬럼
     - `job_id` (FK → Production_Log.job_id)
     - `material_id` (FK → Raw_Materials.material_id)
     - `quantity_used`
   - (job_id, material_id) 복합 PK로 동일 Job에서 같은 재료 중복 기록 방지
   - 관계
     - `ProductionLog.usages` ↔ `ProductionUsage.job`
     - `RawMaterial.production_usages` ↔ `ProductionUsage.material`

3. **생산 Job 생성 API `/production/create` 구현**
   - 요청 스키마: `ProductionCreateRequest`
     - `gift_id`: 생산할 선물 ID
     - `produced_quantity`: 생산 수량
     - `staff_id`: 생산을 수행한 StaffID
   - 동작 로직
     1. **사전 검증 (트랜잭션 외부)**
        - 선물 존재 여부 확인
        - 생산 수량 (> 0) 검증
        - Gift_BOM 레시피 존재 여부 확인
        - 레시피 + 생산 수량 기준으로 재료별 필요 수량 계산
        - 현재 재고와 비교하여 **부족한 재료를 `shortages` 리스트로 수집**
        - 부족한 재료가 하나라도 있으면
          - 400 에러 반환
          - `detail` 에 `message` 및 `shortages` 배열 포함  
            (`material_id`, `material_name`, `required`, `available`)
          - DB 변경 없이 종료
     2. **트랜잭션 구간 (transactional_session)**
        - 재료 충분할 경우에만 진입
        - Raw_Materials 재고 차감
        - Finished_Goods 재고 증가
        - `Production_Log` 1건 INSERT
        - 각 BOM 항목에 대해 `Production_Usage` 여러 건 INSERT
        - 예외 없으면 COMMIT, 예외 발생 시 ROLLBACK 후 에러 반환

4. **트랜잭션 유틸 추가**
   - `backend/utils/transactions.py`
   - `transactional_session(db)` 컨텍스트 매니저 정의
     - `with transactional_session(db):` 블록 내에서 예외 없으면 `commit()`
     - 예외 발생 시 `rollback()` 후 예외 재전파
   - `/production/create` 에 적용하여 트랜잭션 처리 로직을 공통 패턴으로 정리

5. **/gift/produce 용도 명시**
   - `/gift/produce` 주석에
     - Gift_BOM 기반 재고 검증 + 재고 증감만 처리하는 **간단 생산/재고 조정용 API**임을 명시
     - Production_Log / Production_Usage 기록은 남기지 않는다는 점을 추가
   - 실제 GiftElf 생산 플로우에서는 `/production/create` 사용을 권장


## 변경된 API 정리

- `POST /production/create`
  - 설명: 생산 Job 1건 생성
  - 기능:
    - Gift_BOM 레시피 기반 재료 검증
    - 재료 부족 시: 부족 재료 전체 목록을 포함한 400 응답
    - 재료 충분 시:
      - 원자재 재고 차감
      - 선물 재고 증가
      - Production_Log / Production_Usage 기록
      - 트랜잭션 COMMIT

- (기존) `POST /gift/produce`
  - Gift_BOM을 사용한 간단 생산/재고 조정용 API
  - 재료 검증 + 재고 차감/증가는 수행하지만,
    Production_Log / Production_Usage 기록은 남기지 않음


## 테스트

Swagger `/docs` 를 통해 아래 시나리오를 수동 테스트했다.

1. **재료 부족 시 생산 실패**
   - 특정 선물에 대해 Raw_Materials 재고를 의도적으로 부족하게 설정
   - `POST /production/create` 호출
   - 기대 결과:
     - 400 응답
     - `detail.message` 에 부족 재료 이름들이 포함
     - `detail.shortages` 배열에 각 재료별 `required` / `available` 정보가 포함
     - Raw_Materials / Finished_Goods / Production_Log / Production_Usage 모두 변경되지 않음

2. **재료 충분 시 생산 성공**
   - `/gift/materials/mine` 등을 통해 필요한 재료를 충분히 채운 뒤
   - `POST /production/create` 호출
   - 기대 결과:
     - 200 응답
     - 응답 본문에 `job_id`, `gift_id`, `quantity_produced`, `produced_by_staff_id`, `new_gift_stock` 포함
     - Raw_Materials 재고가 사용량만큼 감소
     - Finished_Goods 재고가 생산 수량만큼 증가
     - Production_Log 에 생산 Job 1건 INSERT
     - Production_Usage 에 해당 JobID와 재료별 사용량 INSERT

3. **동일 선물에 대한 반복 생산 테스트**
   - 같은 `gift_id` 에 대해 `/production/create` 를 여러 번 호출
   - 기대 결과:
     - 각 호출마다 새로운 `job_id` 가 부여됨
     - Finished_Goods 재고와 Raw_Materials 재고가 누적 반영
     - Production_Log / Production_Usage 테이블에서
       - Job 단위 로그와 재료 사용 내역이 일관되게 증가하는지 확인
