### PR TITLE
#ISSUE14 - [FEAT] - 루돌프 Reindeer 모델 및 상태 변경 API 구현

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from contextlib import asynccontextmanager
 
 from backend.database import Base, engine, SessionLocal
-from backend.utils.seed import seed_raw_materials, seed_finished_goods, seed_gift_bom
+from backend.utils.seed import seed_raw_materials, seed_finished_goods, seed_gift_bom, seed_reindeer
 from backend import models
 
 @asynccontextmanager
@@ -11,12 +11,14 @@ async def lifespan(app: FastAPI):
     seed_finished_goods()
     seed_raw_materials()
     seed_gift_bom()
+    seed_reindeer()
     yield 
     print("Shutting down...")
 
 app = FastAPI(lifespan=lifespan)
 
 # --- Routers ---
-from backend.routers import gift, production
+from backend.routers import gift, production, reindeer
 app.include_router(gift.router)
 app.include_router(production.router)
+app.include_router(reindeer.router)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,1 +1,2 @@
 from backend.models.gift import RawMaterial, FinishedGoods, GiftBOM, ProductionLog, ProductionUsage
+from backend.models.reindeer import Reindeer

--- a/backend/models/reindeer.py
+++ b/backend/models/reindeer.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String
+from backend.database import Base
+
+class Reindeer(Base):
+    __tablename__ = "reindeer"
+
+    reindeer_id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+
+    # team_name = Column(String, nullable=True)
+
+    current_stamina = Column(Integer, nullable=False, default=100)
+    current_magic = Column(Integer, nullable=False, default=100)
+
+    # Ready / Resting / OnDelivery
+    status = Column(String, nullable=False, default="Ready")
+    # TODO: Santa 배정 로직에서는 status == "Ready" 인 루돌프만 선택하도록 제한

--- a/backend/routers/reindeer.py
+++ b/backend/routers/reindeer.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models.reindeer import Reindeer
+from backend.schemas.reindeer import ReindeerResponse, ReindeerUpdateStatus
+
+router = APIRouter(prefix="/reindeer", tags=["reindeer"])
+
+
+# 전체 루돌프 목록 조회
+# GET /reindeer/
+@router.get("/", response_model=list[ReindeerResponse])
+def list_reindeer(db: Session = Depends(get_db)):
+    reindeers = db.query(Reindeer).order_by(Reindeer.reindeer_id).all()
+    return reindeers
+
+
+# 상태 변경
+# POST /reindeer/update-status
+@router.post("/update-status", response_model=ReindeerResponse)
+def update_reindeer_status(
+    payload: ReindeerUpdateStatus,
+    db: Session = Depends(get_db),
+):
+    # 존재 여부 확인
+    reindeer = (
+        db.query(Reindeer)
+        .filter(Reindeer.reindeer_id == payload.reindeer_id)
+        .first()
+    )
+    if not reindeer:
+        raise HTTPException(status_code=404, detail="Reindeer not found")
+
+    # 상태 변경
+    reindeer.status = payload.status
+
+    # 커밋 & 갱신
+    db.commit()
+    db.refresh(reindeer)
+
+    return reindeer

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,1 +1,2 @@
 from backend.schemas.gift import MaterialUpdate, Gift, ProduceRequest
+from backend.schemas.reindeer import ReindeerBase, ReindeerResponse, ReindeerUpdateStatus

--- a/backend/schemas/reindeer.py
+++ b/backend/schemas/reindeer.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel, field_validator
+
+# 공통 필드 (조회/응답용)
+class ReindeerBase(BaseModel):
+    name: str
+    # team_name: str | None = None
+    current_stamina: int = 100
+    current_magic: int = 100
+    status: str = "Ready"  # Ready / Resting / OnDelivery
+
+    # 상태 검증
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        allowed = {"Ready", "Resting", "OnDelivery"}
+        if v not in allowed:
+            raise ValueError(f"status must be one of {allowed}")
+        return v
+
+
+# 조회 응답용 스키마
+class ReindeerResponse(ReindeerBase):
+    reindeer_id: int
+
+    class Config:
+        from_attributes = True
+
+
+# 상태만 바꿀 때 쓸 스키마
+class ReindeerUpdateStatus(BaseModel):
+    reindeer_id: int
+    status: str  # Ready / Resting / OnDelivery
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        allowed = {"Ready", "Resting", "OnDelivery"}
+        if v not in allowed:
+            raise ValueError(f"status must be one of {allowed}")
+        return v

--- a/backend/utils/seed.py
+++ b/backend/utils/seed.py
@@ -1,5 +1,6 @@
 from backend.database import SessionLocal
 from backend.models.gift import RawMaterial, FinishedGoods, GiftBOM
+from backend.models.reindeer import Reindeer
 
 def seed_raw_materials():
     db = SessionLocal()
@@ -81,6 +82,36 @@ def seed_gift_bom():
                     output_gift_id=out_id,
                     input_material_id=in_mat,
                     quantity_required=qty,
+                )
+            )
+
+    db.commit()
+    db.close()
+    
+def seed_reindeer():
+    db = SessionLocal()
+
+    default_reindeers = [
+        (1, "빅슨"),
+        (2, "도너"),
+        (3, "댄서"),
+        (4, "큐피드"),
+        (5, "대셔"),
+        (6, "코멧"),
+        (7, "프랜서"),
+        (8, "루돌프"),
+    ]
+
+    for rid, name in default_reindeers:
+        exists = db.query(Reindeer).filter_by(reindeer_id=rid).first()
+        if not exists:
+            db.add(
+                Reindeer(
+                    reindeer_id=rid,
+                    name=name,
+                    current_stamina=100,
+                    current_magic=100,
+                    status="Ready",
                 )
             )
 


### PR DESCRIPTION
## 개요

Keeper 역할을 위한 **루돌프 관리 기능**을 추가했습니다.  
`Reindeer` 테이블을 기반으로 루돌프 정보를 조회하고 상태(Ready / Resting / OnDelivery)를 변경할 수 있는 API를 구현했습니다.  
추후 Santa 쪽에서 **Ready 상태의 루돌프만 배정**할 수 있도록 TODO도 함께 남겨두었습니다.

## 주요 변경 사항

1. **Reindeer 모델 생성**
   - `backend/models/reindeer.py`
   - 컬럼
     - `reindeer_id` (PK, int)
     - `name` (varchar, not null)
     - `current_stamina` (int, default 100)
     - `current_magic` (int, default 100)
     - `status` (varchar, default `"Ready"`)
   - `TeamName` 컬럼은 주석 처리 (현재 사용하지 않음)
   - Santa 배정 시 `status == "Ready"`만 선택하도록 TODO 주석 추가

2. **Reindeer 스키마 정의**
   - `backend/schemas/reindeer.py`
   - `ReindeerBase`, `ReindeerResponse`, `ReindeerUpdateStatus` 추가
   - Pydantic v2 기준 `from_attributes = True` 설정
   - `status` 필드는 `"Ready" | "Resting" | "OnDelivery"`만 허용하도록 validator 추가

3. **Reindeer 라우터 추가**
   - `backend/routers/reindeer.py`
   - `GET /reindeer`
     - 전체 루돌프 목록 조회
     - `ReindeerResponse` 리스트로 응답
   - `POST /reindeer/update-status`
     - Request Body: `ReindeerUpdateStatus`
     - 존재하지 않는 `reindeer_id`인 경우 404 반환
     - 상태 업데이트 후 변경된 Reindeer 정보 반환
   - `main.py`에 `reindeer.router` 등록

4. **루돌프 초기 데이터 seed**
   - `backend/utils/seed.py`
   - `seed_reindeer()` 구현
   - 초기 데이터
     - 1: 빅슨
     - 2: 도너
     - 3: 댄서
     - 4: 큐피드
     - 5: 대셔
     - 6: 코멧
     - 7: 프랜서
     - 8: 루돌프
   - 모든 루돌프는 `current_stamina = 100`, `current_magic = 100`, `status = "Ready"`로 초기화