### PR TITLE
#ISSUE11 - [FEAT] - Gift_BOM 레시피 기반 선물 생산 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ venv/
 # IDE
 .vscode/
 .idea/
+
+# Local scripts / Personal config
+main.pysource

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 
 from backend.database import Base, engine, SessionLocal
 from backend.utils.seed import seed_raw_materials, seed_finished_goods, seed_gift_bom, seed_reindeer
-from backend import models
+from backend.models import gift, child, reindeer
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -18,7 +18,8 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # --- Routers ---
-from backend.routers import gift, production, reindeer
+from backend.routers import gift, production, reindeer, list_elf_child
 app.include_router(gift.router)
 app.include_router(production.router)
 app.include_router(reindeer.router)
+app.include_router(list_elf_child.router)

--- a/backend/models/child.py
+++ b/backend/models/child.py
@@ -1,0 +1,43 @@
+'''
+Child / Wishlist / FinishedGoods
+- Child: 아이 기본 정보
+- Wishlist: 아이가 원하는 선물 목록 (1:N)
+- FinishedGoods: 선물 테이블 (GiftID 유효성 검증용)
+'''
+
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+from backend.database import Base
+
+# Child (아이 정보 테이블)
+class Child(Base):
+    __tablename__ = "child"
+
+    ChildID = Column(Integer, primary_key=True, autoincrement=True)
+    Name = Column(String, nullable=False)
+    Address = Column(String, nullable=False)
+    RegionID = Column(Integer, nullable=False)
+
+    # 아이 등록 시 기본값은 모두 Pending
+    StatusCode = Column(String, nullable=False, default="Pending")
+    DeliveryStatusCode = Column(String, nullable=False, default="Pending")
+
+    # Child 1명 -> Wishlist 여러 개 (1:N 관계)
+    wishlist_items = relationship(
+        "Wishlist",
+        back_populates="child",
+        cascade="all, delete-orphan"
+    )
+
+
+# Wishlist (아이의 선호 선물 목록)
+class Wishlist(Base):
+    __tablename__ = "wishlist"
+
+    WishlistID = Column(Integer, primary_key=True, autoincrement=True)
+    ChildID = Column(Integer, ForeignKey("child.ChildID"), nullable=False) # 어떤 아이의 wishlist인지
+    # 어떤 선물인지
+    GiftID = Column(Integer, ForeignKey("Finished_Goods.gift_id"), nullable=False)
+    Priority = Column(Integer, nullable=False)  # 우선순위(1이 가장 높음)
+
+    child = relationship("Child", back_populates="wishlist_items")

--- a/backend/routers/list_elf_child.py
+++ b/backend/routers/list_elf_child.py
@@ -1,0 +1,98 @@
+'''
+아이(Child) + Wishlist를 한 번에 생성하는 API
+- Child INSERT
+- Wishlist 여러 개 INSERT
+- 중간에 실패하면 전부 롤백 (트랜잭션 처리)
+'''
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models.child import Child, Wishlist
+from backend.schemas.child_schema import ChildCreate, ChildOut, WishlistItemOut
+from backend.models.gift import FinishedGoods
+
+router = APIRouter(
+    prefix="/list-elf/child",
+    tags=["List Elf"],
+)
+
+
+@router.post("/create", response_model=ChildOut, status_code=status.HTTP_201_CREATED)
+def create_child_with_wishlist(payload: ChildCreate, db: Session = Depends(get_db)):
+    '''
+    Child와 Wishlist를 한 요청에서 생성하는 API
+    '''
+
+    # priority 중복 최종 체크 (스키마에서 한 번 걸러도 서버에서 다시 체크)
+    priorities = [item.priority for item in payload.wishlist]
+    if len(priorities) != len(set(priorities)):
+        raise HTTPException(status_code=400, detail="priority가 중복됩니다.")
+
+    # 실제 DB에 존재하는 GiftID인지 검사
+    gift_ids = {item.gift_id for item in payload.wishlist}
+    existing_gifts = (
+    db.query(FinishedGoods)
+      .filter(FinishedGoods.gift_id.in_(gift_ids))
+      .all()
+    )
+    existing_ids = {g.gift_id for g in existing_gifts}
+
+    missing = gift_ids - existing_ids
+    if missing:
+        raise HTTPException(status_code=400, detail=f"존재하지 않는 GiftID: {missing}")
+
+    try:
+        # Child INSERT
+        child = Child(
+            Name=payload.name,
+            Address=payload.address,
+            RegionID=payload.region_id,
+            StatusCode="Pending",         # 기본 상태
+            DeliveryStatusCode="Pending"  # 기본 배송 상태
+        )
+
+        db.add(child)
+        db.flush()  # ChildID 확보 (commit 전이지만 FK에 사용 가능)
+
+        # Wishlist 여러 개 INSERT
+        wishlist_rows = []
+        for item in payload.wishlist:
+            w = Wishlist(
+                ChildID=child.ChildID,   # 방금 생성한 Child와 연결
+                GiftID=item.gift_id,
+                Priority=item.priority,
+            )
+            db.add(w)
+            wishlist_rows.append(w)
+
+        db.commit()  # 모든 INSERT 성공하면 commit
+
+    # except Exception:
+    #     db.rollback()  # 하나라도 실패하면 전부 취소
+    #     raise HTTPException(status_code=500, detail="데이터 생성 중 오류 발생")
+
+    except Exception as e: # 정확한 오류를 찾기 위해 사용 
+        db.rollback()
+        print("ERROR:", e)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+    # 응답 데이터 형태 맞추기
+    return ChildOut(
+        child_id=child.ChildID,
+        name=child.Name,
+        address=child.Address,
+        region_id=child.RegionID,
+        status_code=child.StatusCode,
+        delivery_status_code=child.DeliveryStatusCode,
+        wishlist=[
+            WishlistItemOut(
+                wishlist_id=w.WishlistID,
+                gift_id=w.GiftID,
+                priority=w.Priority
+            )
+            for w in wishlist_rows
+        ]
+    )

--- a/backend/schemas/child_schema.py
+++ b/backend/schemas/child_schema.py
@@ -1,0 +1,63 @@
+'''
+클라이언트가 보내는 JSON 형식을 검증하는 스키마
+- ChildCreate: 아이 + wishlist 여러 개 생성할 때 사용
+- WishlistItem: wishlist 안에서 반복되는 구조
+'''
+
+from typing import List
+from pydantic import BaseModel, Field, validator
+
+
+# 하나의 wishlist 요소
+class WishlistItem(BaseModel):
+    gift_id: int = Field(..., description="Finished_Goods의 GiftID")
+    priority: int = Field(..., ge=1, description="1이 가장 높은 우선순위")
+
+    class Config:
+        orm_mode = True
+
+
+# 아이 + 위시리스트 동시 생성 시 입력받는 JSON 구조
+class ChildCreate(BaseModel):
+    name: str
+    address: str
+    region_id: int
+    wishlist: List[WishlistItem]
+
+    # wishlist가 비어있으면 안 됨
+    @validator("wishlist")
+    def check_not_empty(cls, v):
+        if not v:
+            raise ValueError("wishlist는 최소 1개 이상 필요합니다.")
+        return v
+
+    # priority 중복도 막음
+    @validator("wishlist")
+    def check_priority_unique(cls, v):
+        priorities = [i.priority for i in v]
+        if len(priorities) != len(set(priorities)):
+            raise ValueError("priority 값이 중복될 수 없습니다.")
+        return v
+
+
+# 응답 형태 정의
+class WishlistItemOut(BaseModel):
+    wishlist_id: int
+    gift_id: int
+    priority: int
+
+    class Config:
+        orm_mode = True
+
+
+class ChildOut(BaseModel):
+    child_id: int
+    name: str
+    address: str
+    region_id: int
+    status_code: str
+    delivery_status_code: str
+    wishlist: list[WishlistItemOut]
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
Child 생성과 동시에 Wishlist(선호 선물 목록)를 함께 저장하는 기능을 구현했습니다.  
SCDMS(List Elf 모듈)의 핵심 기능 중 하나로, 이후 Rules 적용 및 배송 대상 선정 기능을 테스트하기 위한 기반 데이터를 구축하기 위해 필요한 기능입니다.

해당 PR은 Issue #11의 요구사항을 모두 충족합니다.

---

## 주요 구현 내용

### 1) Child & Wishlist 모델 구현
- Child 모델 생성
  - 기본 StatusCode = "Pending"
  - 기본 DeliveryStatusCode = "Pending"
- Wishlist 모델 생성
  - Child 1:N 관계 구성
  - GiftID(Finished_Goods.gift_id) 외래키 연결

### 2) 스키마(Schema) 구현
- `ChildCreate`, `WishlistItem` 스키마 작성
- 필수 값 검증
- priority 중복 검사(Pydantic + 서버 양쪽에서 double-check)

### 3) Child + Wishlist 동시 생성 API 구현
**POST /list-elf/child/create**
- Child 저장 후 db.flush()로 ChildID 확보
- Wishlist 배열 다중 INSERT 처리
- GiftID 존재 여부 검증 (FinishedGoods 테이블 조회)
- 트랜잭션 처리  
  - 중간 실패 시 전체 rollback
  - 성공 시 commit

### 4) 예외 처리
- priority 중복 시 400 오류 반환
- 존재하지 않는 GiftID 사용 시 400 오류 반환
- DB 오류 발생 시 500 반환 + rollback 처리

### 5) 테스트
- Swagger UI에서 정상 응답 확인
- Postman으로 Child + Wishlist 정상 생성 확인
- FK 조건 충족 여부 확인 (wishlist.ChildID / GiftID)
- 자동 증가 ChildID 정상 작동 확인

---

## 변경된 파일
- `backend/models/child.py`
- `backend/schemas/child_schema.py`
- `backend/routers/list_elf_child.py`
- `backend/main.py` (router 등록)

---

## Issue
Closes #11

---

## 추가 예정 기능 (다음 이슈에서 처리)
- Child Update / Child 조회 API
- Wishlist 개별 추가 / 수정 / 삭제
- Rules CRUD + Criteria 처리
- Rule 기반 Child 상태 업데이트
- Santa 배송 대상 선정 알고리즘
