### PR TITLE
 #ISSUE20 - [FEAT] - Child 수정/삭제 및 Wishlist CRUD 기능 구현 

### DIFF
--- a/backend/models/child.py
+++ b/backend/models/child.py
@@ -1,16 +1,18 @@
 '''
-Child / Wishlist / FinishedGoods
+Child / Wishlist
 - Child: 아이 기본 정보
 - Wishlist: 아이가 원하는 선물 목록 (1:N)
-- FinishedGoods: 선물 테이블 (GiftID 유효성 검증용)
+- StatusCode / DeliveryStatusCode 는 기본값 "Pending"
+- wishlist_items 관계에 cascade 설정 -> Child 삭제 시 관련 Wishlist 자동 삭제
 '''
-
 from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship
 from backend.database import Base
 
-# Child (아이 정보 테이블)
+
+
 class Child(Base):
+
     __tablename__ = "child"
 
     ChildID = Column(Integer, primary_key=True, autoincrement=True)
@@ -18,26 +20,44 @@ class Child(Base):
     Address = Column(String, nullable=False)
     RegionID = Column(Integer, nullable=False)
 
-    # 아이 등록 시 기본값은 모두 Pending
     StatusCode = Column(String, nullable=False, default="Pending")
     DeliveryStatusCode = Column(String, nullable=False, default="Pending")
 
-    # Child 1명 -> Wishlist 여러 개 (1:N 관계)
+    # Child 1명 -> Wishlist N개
     wishlist_items = relationship(
         "Wishlist",
         back_populates="child",
-        cascade="all, delete-orphan"
+        cascade="all, delete-orphan",   # SQLAlchemy 내부적으로도 삭제
+        passive_deletes=True            # DB의 ON DELETE CASCADE 사용
     )
 
 
-# Wishlist (아이의 선호 선물 목록)
 class Wishlist(Base):
+    '''
+    Wishlist (아이의 선호 선물)
+    - ChildID: 삭제 시 CASCADE
+    - GiftID : Finished_Goods.gift_id 참조
+    '''
+
     __tablename__ = "wishlist"
 
     WishlistID = Column(Integer, primary_key=True, autoincrement=True)
-    ChildID = Column(Integer, ForeignKey("child.ChildID"), nullable=False) # 어떤 아이의 wishlist인지
-    # 어떤 선물인지
-    GiftID = Column(Integer, ForeignKey("Finished_Goods.gift_id"), nullable=False)
-    Priority = Column(Integer, nullable=False)  # 우선순위(1이 가장 높음)
 
+    # Child 삭제 시 자동 삭제
+    ChildID = Column(
+        Integer,
+        ForeignKey("child.ChildID", ondelete="CASCADE"),
+        nullable=False
+    )
+
+    # 선물 ID (Finished_Goods.gift_id)
+    GiftID = Column(
+        Integer,
+        ForeignKey("Finished_Goods.gift_id"),
+        nullable=False
+    )
+
+    Priority = Column(Integer, nullable=False)
+
+    # 역참조
     child = relationship("Child", back_populates="wishlist_items")

--- a/backend/routers/list_elf_child.py
+++ b/backend/routers/list_elf_child.py
@@ -3,21 +3,30 @@
 - Child INSERT
 - Wishlist 여러 개 INSERT
 - 중간에 실패하면 전부 롤백 (트랜잭션 처리)
+- Child 수정 (PATCH)
+- Child 삭제 (DELETE)
+- Child 상세 조회 (Child + Wishlist)
+- Wishlist 생성
+- Wishlist 수정
+- Wishlist 삭제
 '''
-
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from backend.database import get_db
 from backend.models.child import Child, Wishlist
-from backend.schemas.child_schema import ChildCreate, ChildOut, WishlistItemOut
 from backend.models.gift import FinishedGoods
+from backend.schemas.child_schema import (
+    ChildCreate, ChildUpdate,
+    ChildOut, ChildDetailOut,
+    WishlistCreate, WishlistUpdate,
+    WishlistItemOut
+)
 
 router = APIRouter(
     prefix="/list-elf/child",
-    tags=["List Elf"],
+    tags=["List Elf"]
 )
-
 
 @router.post("/create", response_model=ChildOut, status_code=status.HTTP_201_CREATED)
 def create_child_with_wishlist(payload: ChildCreate, db: Session = Depends(get_db)):
@@ -96,3 +105,173 @@ def create_child_with_wishlist(payload: ChildCreate, db: Session = Depends(get_d
             for w in wishlist_rows
         ]
     )
+
+# Child 수정 (PATCH)
+@router.patch("/{child_id}", response_model=ChildOut)
+def update_child(child_id: int, payload: ChildUpdate, db: Session = Depends(get_db)):
+    '''
+    Child 기본 정보 수정
+    '''
+
+    child = db.query(Child).filter(Child.ChildID == child_id).first()
+    if not child:
+        raise HTTPException(404, "Child not found")
+
+    update_data = payload.dict(exclude_unset=True)
+
+    # SQLAlchemy 컬럼명이 대문자로 시작함(Name, Address 등)
+    for key, value in update_data.items():
+        setattr(child, key.capitalize(), value)
+
+    db.commit()
+    db.refresh(child)
+
+    return ChildOut(
+        child_id=child.ChildID,
+        name=child.Name,
+        address=child.Address,
+        region_id=child.RegionID,
+        status_code=child.StatusCode,
+        delivery_status_code=child.DeliveryStatusCode,
+        wishlist=[
+            WishlistItemOut(
+                wishlist_id=w.WishlistID,
+                gift_id=w.GiftID,
+                priority=w.Priority
+            )
+            for w in child.wishlist_items
+        ]
+    )
+
+
+# Child 삭제 (DELETE)
+@router.delete("/{child_id}")
+def delete_child(child_id: int, db: Session = Depends(get_db)):
+    '''
+    Child 삭제
+    - wishlist는 CASCADE로 자동 삭제됨
+    '''
+
+    child = db.query(Child).filter(Child.ChildID == child_id).first()
+    if not child:
+        raise HTTPException(404, "Child not found")
+
+    db.delete(child)
+    db.commit()
+
+    return {"message": "Child and wishlist deleted successfully"}
+
+
+# Child 상세 조회 (Child + Wishlist)
+@router.get("/{child_id}/details", response_model=ChildDetailOut)
+def get_child_details(child_id: int, db: Session = Depends(get_db)):
+    '''
+    Child + Wishlist 묶음 조회
+    UI/UX 화면에서 '아이 상세 페이지'를 만들 때 필수
+    '''
+
+    child = db.query(Child).filter(Child.ChildID == child_id).first()
+    if not child:
+        raise HTTPException(404, "Child not found")
+
+    return ChildDetailOut(
+        child_id=child.ChildID,
+        name=child.Name,
+        address=child.Address,
+        region_id=child.RegionID,
+        status_code=child.StatusCode,
+        delivery_status_code=child.DeliveryStatusCode,
+        wishlist=[
+            WishlistItemOut(
+                wishlist_id=w.WishlistID,
+                gift_id=w.GiftID,
+                priority=w.Priority,
+            )
+            for w in child.wishlist_items
+        ]
+    )
+
+
+# Wishlist 생성
+@router.post("/{child_id}/wishlist", response_model=WishlistItemOut)
+def add_wishlist(child_id: int, payload: WishlistCreate, db: Session = Depends(get_db)):
+    '''
+    Child에 Wishlist 항목 추가
+    '''
+
+    child = db.query(Child).filter(Child.ChildID == child_id).first()
+    if not child:
+        raise HTTPException(404, "Child not found")
+
+    gift = db.query(FinishedGoods).filter(FinishedGoods.gift_id == payload.gift_id).first()
+    if not gift:
+        raise HTTPException(404, "Gift not found")
+
+    wishlist = Wishlist(
+        ChildID=child_id,
+        GiftID=payload.gift_id,
+        Priority=payload.priority
+    )
+
+    db.add(wishlist)
+    db.commit()
+    db.refresh(wishlist)
+
+    return WishlistItemOut(
+        wishlist_id=wishlist.WishlistID,
+        gift_id=wishlist.GiftID,
+        priority=wishlist.Priority
+    )
+
+
+# Wishlist 수정
+@router.patch("/wishlist/{wishlist_id}", response_model=WishlistItemOut)
+def update_wishlist(wishlist_id: int, payload: WishlistUpdate, db: Session = Depends(get_db)):
+    """
+    Wishlist 항목 단일 수정
+    """
+
+    wishlist = db.query(Wishlist).filter(Wishlist.WishlistID == wishlist_id).first()
+    if not wishlist:
+        raise HTTPException(404, "Wishlist item not found")
+
+    data = payload.dict(exclude_unset=True)
+
+    # gift_id 수정 시 유효한 Gift인지 확인
+    if "gift_id" in data:
+        gift = db.query(FinishedGoods).filter(FinishedGoods.gift_id == data["gift_id"]).first()
+        if not gift:
+            raise HTTPException(404, "Gift not found")
+
+    # 🔥 필드 매핑 정확히 처리
+    for key, value in data.items():
+        if key == "gift_id":
+            setattr(wishlist, "GiftID", value)
+        elif key == "priority":
+            setattr(wishlist, "Priority", value)
+
+    db.commit()
+    db.refresh(wishlist)
+
+    return WishlistItemOut(
+        wishlist_id=wishlist.WishlistID,
+        gift_id=wishlist.GiftID,
+        priority=wishlist.Priority
+    )
+
+
+# Wishlist 삭제
+@router.delete("/wishlist/{wishlist_id}")
+def delete_wishlist(wishlist_id: int, db: Session = Depends(get_db)):
+    '''
+    Wishlist 항목 단일 삭제
+    '''
+
+    wishlist = db.query(Wishlist).filter(Wishlist.WishlistID == wishlist_id).first()
+    if not wishlist:
+        raise HTTPException(404, "Wishlist item not found")
+
+    db.delete(wishlist)
+    db.commit()
+
+    return {"message": "Wishlist item deleted successfully"}

--- a/backend/schemas/child_schema.py
+++ b/backend/schemas/child_schema.py
@@ -1,63 +1,129 @@
 '''
 클라이언트가 보내는 JSON 형식을 검증하는 스키마
-- ChildCreate: 아이 + wishlist 여러 개 생성할 때 사용
-- WishlistItem: wishlist 안에서 반복되는 구조
+
+(주요 기능)
+- Child 생성 스키마(ChildCreate)
+- Child 수정 스키마(ChildUpdate)
+- Wishlist CRUD 스키마(WishlistCreate, WishlistUpdate)
+- Child + Wishlist 묶음 출력 스키마(ChildOut, ChildDetailOut)
 '''
 
 from typing import List
 from pydantic import BaseModel, Field, validator
 
+from typing import List, Optional
+from pydantic import BaseModel, Field, validator
+from pydantic import ConfigDict
 
-# 하나의 wishlist 요소
+
+# 1) Wishlist 단일 요소 입력용
 class WishlistItem(BaseModel):
-    gift_id: int = Field(..., description="Finished_Goods의 GiftID")
-    priority: int = Field(..., ge=1, description="1이 가장 높은 우선순위")
+    '''
+    ChildCreate 시 사용되는 위시리스트 단일 요소.
+    '''
 
-    class Config:
-        from_attributes = True
+    gift_id: int = Field(..., description="Finished_Goods.gift_id")
+    priority: int = Field(..., ge=1, description="우선순위 (1이 가장 높음)")
+
+    model_config = ConfigDict(from_attributes=True)
 
 
-# 아이 + 위시리스트 동시 생성 시 입력받는 JSON 구조
+# 2) Child + Wishlist 동시 생성 시 사용
 class ChildCreate(BaseModel):
+    '''
+    Child와 wishlist 여러 개를 한 번에 생성.
+    '''
+
     name: str
     address: str
     region_id: int
     wishlist: List[WishlistItem]
 
-    # wishlist가 비어있으면 안 됨
     @validator("wishlist")
-    def check_not_empty(cls, v):
+    def validate_not_empty(cls, v):
         if not v:
             raise ValueError("wishlist는 최소 1개 이상 필요합니다.")
         return v
 
-    # priority 중복도 막음
     @validator("wishlist")
-    def check_priority_unique(cls, v):
+    def validate_priority_unique(cls, v):
         priorities = [i.priority for i in v]
         if len(priorities) != len(set(priorities)):
             raise ValueError("priority 값이 중복될 수 없습니다.")
         return v
 
 
-# 응답 형태 정의
+# 3) Child 수정용 스키마
+class ChildUpdate(BaseModel):
+    '''
+    Child 기본 정보 수정용 스키마
+    '''
+
+    name: Optional[str] = None
+    address: Optional[str] = None
+    region_id: Optional[int] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# 4) Wishlist CRUD 입력 스키마
+class WishlistCreate(BaseModel):
+    '''
+    Wishlist 항목 생성
+    '''
+    gift_id: int
+    priority: int
+
+
+class WishlistUpdate(BaseModel):
+    '''
+    Wishlist 항목 수정
+    '''
+    gift_id: Optional[int] = None
+    priority: Optional[int] = None
+
+
+# 5) 출력용 스키마
 class WishlistItemOut(BaseModel):
+    '''
+    서버 응답용 wishlist item
+    '''
+
     wishlist_id: int
     gift_id: int
     priority: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ChildOut(BaseModel):
+    '''
+    Child 생성/수정 후 반환 구조
+    '''
+
     child_id: int
     name: str
     address: str
     region_id: int
     status_code: str
     delivery_status_code: str
-    wishlist: list[WishlistItemOut]
+    wishlist: List[WishlistItemOut]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
+
+
+# Child + Wishlist 묶음 상세 조회
+class ChildDetailOut(BaseModel):
+    '''
+    GET /child/{id}/details 출력 스키마
+    '''
+
+    child_id: int
+    name: str
+    address: str
+    region_id: int
+    status_code: str
+    delivery_status_code: str
+    wishlist: List[WishlistItemOut]
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## 요약(Summary)
Child 정보 관리 기능을 확장하여 Child 수정/삭제 기능과 Wishlist CRUD 기능을 구현했습니다.
또한 Child 삭제 시 Wishlist가 자동 삭제되도록 DB 및 모델 구조를 정상화했습니다.
모든 기능을 Swagger에서 테스트하여 정상적으로 동작을 확인했습니다.

---

## 주요 구현 내용

### 1) Child 수정
- 이름, 주소, 지역 정보 부분 수정 가능
- 변경된 필드만 업데이트하도록 설계

### 2) Child 삭제(DELETE)
- Child 삭제 시 Wishlist 자동 삭제 (ON DELETE CASCADE)
- cascade="all, delete-orphan" + passive_deletes=True 적용

### 3) Child 상세 조회
- Child와 Wishlist 데이터를 통합하여 반환
- 프론트 구현 시 단일 API로 상세 페이지 구성 가능

### 4) Wishlist CRUD
- Wishlist 생성 (gift_id, priority 입력)
- Wishlist 수정 (gift_id 및 priority 변경)
- Wishlist 삭제 (개별 wishlist item 삭제)
- gift_id 유효성 체크 포함

### 5) Pydantic v2 기반 스키마 구조 개선
- model_config = ConfigDict(from_attributes=True) 적용
- ORM 객체 응답 안정성 증가

### 6) SQLAlchemy 모델 구조 정리
- Wishlist → Child FK ondelete="CASCADE" 적용
- relationship cascade 및 passive_deletes 설정

### 7) DB 스키마 정리
- FK 충돌 문제 해결
- 스키마 초기화 후 CASCADE가 정상적으로 반영되도록 재생성

---

## 변경된 파일(Changed Files)

- `backend/models/child.py`
- `backend/schemas/child_schema.py`
- `backend/routers/list_elf_child.py`

---

##  테스트 결과
- [x] Child 생성 성공
- [x] Child 수정 성공
- [x] Child 삭제(CASCADE) 성공
- [x] Wishlist 생성/수정/삭제 성공
- [x] Child 상세 조회 성공
- [x] 모든 CRUD 기능 Swagger에서 검증 완료

---

## 🔗 관련 이슈
Closes #12

