### PR TITLE
#ISSUE25 - [FEAT] -Child 상태 정규화 + ChildNote 추가 + 전체 Child/Wishlist API 업데이트

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,8 +2,10 @@ from fastapi import FastAPI
 from contextlib import asynccontextmanager
 
 from backend.database import Base, engine, SessionLocal
-from backend.utils.seed import seed_raw_materials, seed_finished_goods, seed_gift_bom, seed_reindeer, create_ready_reindeer_view
-from backend.models import gift, child, reindeer
+from backend.utils.seed import (seed_raw_materials, seed_finished_goods, 
+                                seed_gift_bom, seed_reindeer, create_ready_reindeer_view, 
+                                seed_child_status_codes, seed_delivery_status_codes)
+from backend.models import (gift, child, reindeer)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -13,14 +15,18 @@ async def lifespan(app: FastAPI):
     seed_gift_bom()
     seed_reindeer()
     create_ready_reindeer_view()
+    seed_child_status_codes()
+    seed_delivery_status_codes()
     yield 
     print("Shutting down...")
 
 app = FastAPI(lifespan=lifespan)
 
 # --- Routers ---
-from backend.routers import gift, production, reindeer, list_elf_child
+from backend.routers import gift, production, reindeer, list_elf_child, child_status_code, delivery_status_code
 app.include_router(gift.router)
 app.include_router(production.router)
 app.include_router(reindeer.router)
 app.include_router(list_elf_child.router)
+app.include_router(child_status_code.router)     # 아이 상태 코드 라우터
+app.include_router(delivery_status_code.router)  # 배송 상태 코드 라우터

--- a/backend/models/child_status_code.py
+++ b/backend/models/child_status_code.py
@@ -1,0 +1,22 @@
+'''
+ChildStatusCode
+----------------
+아이의 ‘행동/판정’ 상태를 저장하는 기준 테이블.
+
+- 이 테이블은 Child.StatusCode FK의 대상
+- 예: NICE / NAUGHTY / PENDING
+- 배송 상태는 DeliveryStatusCode 테이블에서 관리하므로 여기엔 넣지 않음
+'''
+
+from sqlalchemy import Column, String
+from backend.database import Base
+
+class ChildStatusCode(Base):
+    __tablename__ = "child_status_code"
+
+    # 상태 코드 (PK)
+    # 값 예: NICE, NAUGHTY, PENDING
+    Code = Column(String, primary_key=True)
+
+    # UI / 설명용 문구
+    Description = Column(String, nullable=False)

--- a/backend/models/delivery_status_code.py
+++ b/backend/models/delivery_status_code.py
@@ -1,0 +1,21 @@
+'''
+DeliveryStatusCode
+--------------------
+배송 진행 상태를 저장하는 기준 테이블.
+
+- Child.DeliveryStatusCode FK의 대상
+- 예: PENDING, PACKED, READY, DELIVERED
+- ChildStatusCode와 역할이 다르므로 반드시 분리 관리해야 함
+'''
+
+from sqlalchemy import Column, String
+from backend.database import Base
+
+class DeliveryStatusCode(Base):
+    __tablename__ = "delivery_status_code"
+
+    # 배송 상태 코드 (PK)
+    Code = Column(String, primary_key=True)
+
+    # 설명 (UI용)
+    Description = Column(String, nullable=False)

--- a/backend/routers/child_status_code.py
+++ b/backend/routers/child_status_code.py
@@ -1,0 +1,72 @@
+'''
+Child Status Code Router
+-------------------------
+아이의 판정/행동 상태 목록을 관리하는 라우터.
+
+- ChildStatusCode 테이블의 CRUD 제공
+- Child의 StatusCode가 참조 중이면 DELETE 불가
+'''
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from backend.database import get_db
+
+from backend.models.child_status_code import ChildStatusCode
+from backend.schemas.status_code_schema import StatusCodeCreate, StatusCodeUpdate, StatusCodeOut
+from backend.models.child import Child
+from sqlalchemy import func
+
+router = APIRouter(prefix="/child-status-codes", tags=["Child Status Code"])
+
+
+# 모든 상태 목록 조회
+@router.get("/", response_model=list[StatusCodeOut])
+def get_codes(db: Session = Depends(get_db)):
+    codes = db.query(ChildStatusCode).all()
+    return [StatusCodeOut(code=c.Code, description=c.Description) for c in codes]
+
+
+# 새로운 상태 코드 생성
+@router.post("/", response_model=StatusCodeOut)
+def create_code(payload: StatusCodeCreate, db: Session = Depends(get_db)):
+    exists = db.query(ChildStatusCode).filter(ChildStatusCode.Code == payload.code).first()
+    if exists:
+        raise HTTPException(409, "Code already exists")
+
+    code = ChildStatusCode(Code=payload.code, Description=payload.description)
+    db.add(code)
+    db.commit()
+
+    return StatusCodeOut.from_orm(code)
+
+
+# description 수정
+@router.patch("/{code}", response_model=StatusCodeOut)
+def update_code(code: str, payload: StatusCodeUpdate, db: Session = Depends(get_db)):
+    row = db.query(ChildStatusCode).filter(ChildStatusCode.Code == code).first()
+    if not row:
+        raise HTTPException(404, "Not found")
+
+    row.Description = payload.description
+    db.commit()
+
+    return StatusCodeOut.from_orm(row)
+
+
+# Child가 참조 중이면 삭제 불가
+@router.delete("/{code}")
+def delete_code(code: str, db: Session = Depends(get_db)):
+
+    # Child.StatusCode에서 참조 중인지 체크
+    ref = db.query(func.count(Child.ChildID)).filter(Child.StatusCode == code).scalar()
+
+    if ref > 0:
+        raise HTTPException(409, "Code referenced by child")
+
+    row = db.query(ChildStatusCode).filter(ChildStatusCode.Code == code).first()
+    if not row:
+        raise HTTPException(404, "Not found")
+
+    db.delete(row)
+    db.commit()
+    return {"message": "Deleted"}

--- a/backend/routers/delivery_status_code.py
+++ b/backend/routers/delivery_status_code.py
@@ -1,0 +1,123 @@
+"""
+DeliveryStatusCode Router
+-------------------------
+- 배송 상태 코드 관리용 API
+
+기능:
+1) 배송 상태 코드 목록 조회 (GET /delivery-status-codes/)
+2) 배송 상태 코드 생성 (POST /delivery-status-codes/)
+3) 배송 상태 코드 설명 수정 (PATCH /delivery-status-codes/{code})
+4) 배송 상태 코드 삭제 (DELETE /delivery-status-codes/{code})
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models.delivery_status_code import DeliveryStatusCode
+from backend.schemas.status_code_schema import (
+    StatusCodeCreate,
+    StatusCodeUpdate,
+    StatusCodeOut,
+)
+
+router = APIRouter(
+    prefix="/delivery-status-codes",
+    tags=["Delivery Status Codes"],
+)
+
+
+# ------------------------------------------------------
+# 1) 전체 목록 조회
+# ------------------------------------------------------
+@router.get("/", response_model=list[StatusCodeOut])
+def list_codes(db: Session = Depends(get_db)):
+    """
+    배송 상태 코드 전체 조회
+    """
+    rows = db.query(DeliveryStatusCode).all()
+    # Code / Description -> code / description 변환
+    return [StatusCodeOut.from_orm(r) for r in rows]
+
+
+# ------------------------------------------------------
+# 2) 상태 코드 생성
+# ------------------------------------------------------
+@router.post("/", response_model=StatusCodeOut, status_code=status.HTTP_201_CREATED)
+def create_code(payload: StatusCodeCreate, db: Session = Depends(get_db)):
+    """
+    새로운 배송 상태 코드 생성
+    - code 중복 시 409 Conflict
+    """
+
+    # 이미 같은 code가 있는지 확인
+    existing = (
+        db.query(DeliveryStatusCode)
+        .filter(DeliveryStatusCode.Code == payload.code)
+        .first()
+    )
+    if existing:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="Code already exists")
+
+    # 실제 DB 컬럼 이름: Code / Description (대문자!!)
+    new_row = DeliveryStatusCode(
+        Code=payload.code,
+        Description=payload.description,
+    )
+
+    db.add(new_row)
+    db.commit()
+    db.refresh(new_row)
+
+    return StatusCodeOut.from_orm(new_row)
+
+
+# ------------------------------------------------------
+# 3) 상태 코드 설명 수정 (description만)
+# ------------------------------------------------------
+@router.patch("/{code}", response_model=StatusCodeOut)
+def update_code(code: str, payload: StatusCodeUpdate, db: Session = Depends(get_db)):
+    """
+    배송 상태 코드 설명(description) 수정
+    - code는 PK이므로 변경 불가
+    """
+
+    row = (
+        db.query(DeliveryStatusCode)
+        .filter(DeliveryStatusCode.Code == code)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Code not found")
+
+    # description만 수정
+    row.Description = payload.description
+
+    db.commit()
+    db.refresh(row)
+
+    return StatusCodeOut.from_orm(row)
+
+
+# ------------------------------------------------------
+# 4) 상태 코드 삭제
+# ------------------------------------------------------
+@router.delete("/{code}")
+def delete_code(code: str, db: Session = Depends(get_db)):
+    """
+    배송 상태 코드 삭제
+    - 아직 Child.DeliveryStatusCode에서 FK로 참조 중이면 나중에 막을 수도 있음
+    """
+
+    row = (
+        db.query(DeliveryStatusCode)
+        .filter(DeliveryStatusCode.Code == code)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Code not found")
+
+    db.delete(row)
+    db.commit()
+
+    return {"message": f"DeliveryStatusCode '{code}' deleted successfully"}

--- a/backend/schemas/child_schema.py
+++ b/backend/schemas/child_schema.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field, validator
 from pydantic import ConfigDict
 
 
-# 1) Wishlist 단일 요소 입력용
+# Wishlist 단일 요소 입력용
 class WishlistItem(BaseModel):
     '''
     ChildCreate 시 사용되는 위시리스트 단일 요소.
@@ -28,7 +28,7 @@ class WishlistItem(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-# 2) Child + Wishlist 동시 생성 시 사용
+# Child + Wishlist 동시 생성 시 사용
 class ChildCreate(BaseModel):
     '''
     Child와 wishlist 여러 개를 한 번에 생성.
@@ -37,6 +37,9 @@ class ChildCreate(BaseModel):
     name: str
     address: str
     region_id: int
+    status_code: Optional[str] = "PENDING" 
+    delivery_status_code: Optional[str] = "PENDING"
+    child_note: Optional[str] = None
     wishlist: List[WishlistItem]
 
     @validator("wishlist")
@@ -53,7 +56,7 @@ class ChildCreate(BaseModel):
         return v
 
 
-# 3) Child 수정용 스키마
+# Child 수정용 스키마
 class ChildUpdate(BaseModel):
     '''
     Child 기본 정보 수정용 스키마
@@ -62,11 +65,14 @@ class ChildUpdate(BaseModel):
     name: Optional[str] = None
     address: Optional[str] = None
     region_id: Optional[int] = None
+    status_code: Optional[str] = None 
+    delivery_status_code: Optional[str] = None
+    child_note: Optional[str] = None 
 
     model_config = ConfigDict(from_attributes=True)
 
 
-# 4) Wishlist CRUD 입력 스키마
+# Wishlist CRUD 입력 스키마
 class WishlistCreate(BaseModel):
     '''
     Wishlist 항목 생성
@@ -83,7 +89,7 @@ class WishlistUpdate(BaseModel):
     priority: Optional[int] = None
 
 
-# 5) 출력용 스키마
+# 출력용 스키마
 class WishlistItemOut(BaseModel):
     '''
     서버 응답용 wishlist item
@@ -107,6 +113,7 @@ class ChildOut(BaseModel):
     region_id: int
     status_code: str
     delivery_status_code: str
+    child_note: Optional[str] = None
     wishlist: List[WishlistItemOut]
 
     model_config = ConfigDict(from_attributes=True)
@@ -124,6 +131,7 @@ class ChildDetailOut(BaseModel):
     region_id: int
     status_code: str
     delivery_status_code: str
+    child_note: Optional[str] = None
     wishlist: List[WishlistItemOut]
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/schemas/status_code_schema.py
+++ b/backend/schemas/status_code_schema.py
@@ -1,0 +1,54 @@
+"""
+StatusCode용 Pydantic 스키마
+- ChildStatusCode / DeliveryStatusCode 공통으로 사용
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class StatusCodeBase(BaseModel):
+    # API 입출력에서 쓸 필드 이름 (소문자)
+    code: str
+    description: str
+
+
+class StatusCodeCreate(StatusCodeBase):
+    """
+    상태 코드 생성 요청 바디
+    - code: "Nice", "Naughty", "Pending", "Delivered", "SPECIAL" 등
+    - description: 한국어/설명용 텍스트
+    """
+    pass
+
+
+class StatusCodeUpdate(BaseModel):
+    """
+    상태 코드 수정 요청 바디
+    - description만 수정 (code는 PK라 고정)
+    """
+    description: str
+
+
+class StatusCodeOut(StatusCodeBase):
+    """
+    상태 코드 조회 응답
+    - SQLAlchemy 모델의 Code / Description 필드를
+      API 응답용 code / description으로 변환
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @classmethod
+    def from_orm(cls, obj):
+        # SQLAlchemy 모델에서 실제 컬럼 이름은 대문자일 것임: Code / Description
+        code_value = getattr(obj, "Code", None)
+        if code_value is None:
+            # 혹시 다른 이름을 쓸 수도 있으니 방어 코드
+            code_value = getattr(obj, "StatusCode", None)
+
+        if code_value is None:
+            raise ValueError("StatusCodeOut.from_orm: code 필드를 찾을 수 없습니다.")
+
+        desc_value = getattr(obj, "Description", "")
+
+        return cls(code=code_value, description=desc_value)

--- a/backend/utils/seed.py
+++ b/backend/utils/seed.py
@@ -2,6 +2,10 @@ from sqlalchemy import text
 from backend.database import SessionLocal
 from backend.models.gift import RawMaterial, FinishedGoods, GiftBOM
 from backend.models.reindeer import Reindeer
+from backend.models.child_status_code import ChildStatusCode
+from backend.models.delivery_status_code import DeliveryStatusCode
+
+
 
 def seed_raw_materials():
     db = SessionLocal()
@@ -139,5 +143,35 @@ def create_ready_reindeer_view():
         WHERE status = 'Ready'
           AND current_stamina >= 70;
     """))
+    db.commit()
+    db.close()
+
+# 아이 상태 초기값
+def seed_child_status_codes():
+    db = SessionLocal()
+    codes = [
+        ("PENDING", "판정 대기"),
+        ("NICE", "착한 아이"),
+        ("NAUGHTY", "나쁜 아이"),
+    ]
+    for code, desc in codes:
+        if not db.query(ChildStatusCode).filter_by(Code=code).first():
+            db.add(ChildStatusCode(Code=code, Description=desc))
+    db.commit()
+    db.close()
+
+
+# 배송 상태 초기값
+def seed_delivery_status_codes():
+    db = SessionLocal()
+    codes = [
+        ("PENDING", "배송 대기"),
+        ("PACKED", "포장 완료"),
+        ("READY", "배송 준비 완료"),
+        ("DELIVERED", "배송 완료"),
+    ]
+    for code, desc in codes:
+        if not db.query(DeliveryStatusCode).filter_by(Code=code).first():
+            db.add(DeliveryStatusCode(Code=code, Description=desc))
     db.commit()
     db.close()


### PR DESCRIPTION
## 요약 (Summary)
이번 PR은 Child 상태 코드 정규화(FK 적용),  ChildNote(텍스트 메모) 기능 추가,  그리고 Child/Wishlist 전체 API 구조 업데이트를 포함한 대규모 개선입니다.

- 기존 문자열 기반 상태 코드 제거 ->정규화 테이블 child_status_code / delivery_status_code 생성
- Child 테이블이 상태 코드 테이블을 FK로 참조
- ChildNote 텍스트 메모 기능 추가
- Child/Wishlist API 전체 리팩터링 및 오류 검증 강화
- Seed 자동 생성 로직 추가
- Swagger 기준 전체 CRUD 테스트 통과

---

## ✨ 주요 변경 사항

### Child 상태 코드 정규화 (핵심)
기존:
- Child의 `StatusCode`, `DeliveryStatusCode`는 **그냥 문자열 필드**

변경 후:
- 두 필드를 각각의 상태 코드 테이블을 참조하는 FK 필드로 변경
- DB 무결성 확보 + UI에서 상태 변경 시 값 검증 자동화

#### 추가된 테이블
- `child_status_code(Code, Description)`
- `delivery_status_code(Code, Description)`

#### Child 컬럼 변경
| 기존 | 변경 |
|------|------|
| StatusCode: str | StatusCode → FK(child_status_code.Code) |
| DeliveryStatusCode: str | DeliveryStatusCode → FK(delivery_status_code.Code) |

#### Seed 기본값 추가
child_status_code:
- PENDING  
- NICE  
- NAUGHTY  

delivery_status_code:
- PENDING  
- PACKED  
- READY  
- DELIVERED  

---

### ChildNote 기능 추가
아이별 메모를 기록할 수 있는 텍스트 필드 추가.

- 생성 시 optional  
- 수정 가능  
- 상세 조회에 포함됨  

📌 반영된 필드: `Child.ChildNote`

---

### Child/Wishlist API 전면 리팩터링

#### 수정된 엔드포인트
- `POST /list-elf/child/create`
- `PATCH /list-elf/child/{id}`
- `DELETE /list-elf/child/{id}`
- `GET /list-elf/child/{id}/details`
- `POST /list-elf/child/{child_id}/wishlist`
- `PATCH /list-elf/child/wishlist/{wishlist_id}`
- `DELETE /list-elf/child/wishlist/{wishlist_id}`
- `GET /list-elf/child/stats/gift-demand`

#### 주요 개선점
- FK 구조 반영하여 상태 코드 검증 강화
- ChildNote 포함하도록 출력 스키마 수정
- “priority 중복 체크” 로직 강화
- wishlist CASCADE 삭제 다시 검증
- 오류 메시지 일관성 유지

---

### Status Code 관리용 API 신설
#### Child 상태 코드 API
- `GET /child-status-codes/`
- `POST /child-status-codes/`
- `PATCH /child-status-codes/{code}`
- `DELETE /child-status-codes/{code}`

#### Delivery 상태 코드 API
- `GET /delivery-status-codes/`
- `POST /delivery-status-codes/`
- `PATCH /delivery-status-codes/{code}`
- `DELETE /delivery-status-codes/{code}`

**→ 모든 Child 상태 관련 기능이 독립적으로 유지/관리 가능해짐**

---

##  변경된 파일 목록

###  Models
- `models/child.py`
- `models/status_code.py`

###  Schemas
- `schemas/child_schema.py`
- `schemas/status_code_schema.py`

### Routers
- `routers/list_elf_child.py`
- `routers/child_status_code.py`
- `routers/delivery_status_code.py`

### Seed
- `utils/seed.py`

### App 설정
- `main.py`  
  → 정규화된 상태 코드 seed 추가  
  → 새로운 상태 코드 라우터 등록

---

##  Swagger 테스트 완료 사항
- Child + Wishlist 동시 생성 OK  
- Child 수정/삭제 OK  
- wishlist CRUD OK  
- status code CRUD OK  
- FK 기반 검증 정상 동작  
- gift-demand 통계 OK  

---

##  기타
- 기존의 문자열 기반 상태 코드는 완전히 제거  
- ChildNote 추가로 ListElf 업무 중 ‘아이 기록’ 관리 가능  
- API 안정성 및 데이터 구조적 무결성 크게 향상됨

