### PR TITLE
#ISSUE24 - Gift Demand API 우선순위 기반 집계 및 정렬 로직 구현

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,10 +23,13 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # --- Routers ---
-from backend.routers import gift, production, reindeer, list_elf_child, child_status_code, delivery_status_code
+from backend.routers import (gift, production, reindeer, 
+                             list_elf_child, child_status_code, 
+                             delivery_status_code,list_elf_stats)
 app.include_router(gift.router)
 app.include_router(production.router)
 app.include_router(reindeer.router)
 app.include_router(list_elf_child.router)
 app.include_router(child_status_code.router)     # 아이 상태 코드 라우터
 app.include_router(delivery_status_code.router)  # 배송 상태 코드 라우터
+app.include_router(list_elf_stats.router) # Gift Demand 통계 라우터 등록

--- a/backend/routers/list_elf_child.py
+++ b/backend/routers/list_elf_child.py
@@ -60,8 +60,9 @@ def create_child_with_wishlist(payload: ChildCreate, db: Session = Depends(get_d
             Name=payload.name,
             Address=payload.address,
             RegionID=payload.region_id,
-            StatusCode="PENDING",         # 기본 상태
-            DeliveryStatusCode="PENDING"  # 기본 배송 상태
+            StatusCode=(payload.status_code or "PENDING").upper(), # 기본 상태
+            DeliveryStatusCode=(payload.delivery_status_code or "PENDING").upper(), # 기본 배송 상태
+            ChildNote=payload.child_note
         )
 
         db.add(child)
@@ -98,6 +99,7 @@ def create_child_with_wishlist(payload: ChildCreate, db: Session = Depends(get_d
         region_id=child.RegionID,
         status_code=child.StatusCode,
         delivery_status_code=child.DeliveryStatusCode,
+        child_note=payload.child_note,
         wishlist=[
             WishlistItemOut(
                 wishlist_id=w.WishlistID,
@@ -125,11 +127,11 @@ def update_child(child_id: int, payload: ChildUpdate, db: Session = Depends(get_
 
         # status_code → StatusCode
         if key == "status_code":
-            setattr(child, "StatusCode", value)
+            setattr(child, "StatusCode", value.upper())
 
         # delivery_status_code → DeliveryStatusCode
         elif key == "delivery_status_code":
-            setattr(child, "DeliveryStatusCode", value)
+            setattr(child, "DeliveryStatusCode", value.upper())
 
         # child_note → ChildNote
         elif key == "child_note":

--- a/backend/routers/list_elf_stats.py
+++ b/backend/routers/list_elf_stats.py
@@ -1,0 +1,114 @@
+'''
+통계 API (List Elf)
+-------------------
+1) /gift-demand/summary
+    ->선물별 총 수요량 + 우선순위별(p1/p2/p3) 분포 요약 API
+
+2) /gift-demand/by-priority
+    → Priority = 1/2/3 각각의 Top3 인기 선물 반환 API
+'''
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import func, case
+
+from backend.database import get_db
+from backend.models.child import Child, Wishlist
+from backend.models.gift import FinishedGoods
+from backend.schemas.stat_schema import (
+    GiftDemandOut, PriorityTop3, PriorityGroupOut
+)
+
+router = APIRouter(
+    prefix="/list-elf/stats",
+    tags=["List Elf"]
+)
+
+# Gift Summary API (기존 /gift-demand -> /gift-demand/summary)
+
+@router.get("/gift-demand/summary", response_model=list[GiftDemandOut])
+def get_gift_demand_summary(db: Session = Depends(get_db)):
+    '''
+    기존 /gift-demand API에서 이름 변경된 버전.
+    Nice + Not Delivered 아이들 기준으로
+    GiftID별 총 수요량 + Priority별 수요량(p1/p2/p3)을 집계하는 Summary API.
+    '''
+
+    # CASE WHEN Priority == X THEN 1 ELSE 0 END
+    priority_1 = func.sum(case((Wishlist.Priority == 1, 1), else_=0)).label("p1")
+    priority_2 = func.sum(case((Wishlist.Priority == 2, 1), else_=0)).label("p2")
+    priority_3 = func.sum(case((Wishlist.Priority == 3, 1), else_=0)).label("p3")
+
+    results = (
+        db.query(
+            Wishlist.GiftID.label("gift_id"),
+            func.count(Wishlist.GiftID).label("total"),
+            priority_1,
+            priority_2,
+            priority_3
+        )
+        .join(Child, Wishlist.ChildID == Child.ChildID)
+        .filter(func.upper(Child.StatusCode) == "NICE")
+        .filter(func.upper(Child.DeliveryStatusCode) != "DELIVERED")
+        .group_by(Wishlist.GiftID)
+        .order_by(func.count(Wishlist.GiftID).desc())
+        .all()
+    )
+
+    return [
+        GiftDemandOut(
+            gift_id=row.gift_id,
+            count=row.total,
+            p1=row.p1,
+            p2=row.p2,
+            p3=row.p3
+        )
+        for row in results
+    ]
+
+
+# Priority별 Top3 API (/gift-demand/by-priority)
+
+def get_top3_for_priority(db: Session, priority: int):
+    '''
+    특정 Priority(1/2/3)에 대해 Top3 선물을 반환하는 내부 함수.
+    '''
+    rows = (
+        db.query(
+            Wishlist.GiftID.label("gift_id"),
+            FinishedGoods.gift_name.label("gift_name"),
+            func.count(Wishlist.GiftID).label("count")
+        )
+        .join(Child, Wishlist.ChildID == Child.ChildID)
+        .join(FinishedGoods, Wishlist.GiftID == FinishedGoods.gift_id)
+        .filter(Wishlist.Priority == priority)
+        .filter(func.upper(Child.StatusCode) == "NICE")
+        .filter(func.upper(Child.DeliveryStatusCode) != "DELIVERED")
+        .group_by(Wishlist.GiftID, FinishedGoods.gift_name)
+        .order_by(func.count(Wishlist.GiftID).desc())
+        .limit(3)
+        .all()
+    )
+
+    return [
+        PriorityTop3(
+            gift_id=row.gift_id,
+            gift_name=row.gift_name,
+            count=row.count
+        )
+        for row in rows
+    ]
+
+
+@router.get("/gift-demand/by-priority", response_model=PriorityGroupOut)
+def get_gift_top3_by_priority(db: Session = Depends(get_db)):
+    '''
+    Priority = 1/2/3 각각에서 가장 많이 선택된 Top3 선물을 묶어서 반환.
+    (예: 가장 많이 1순위로 선택된 선물 Top3 등)
+    '''
+
+    return PriorityGroupOut(
+        priority1=get_top3_for_priority(db, 1),
+        priority2=get_top3_for_priority(db, 2),
+        priority3=get_top3_for_priority(db, 3)
+    )

--- a/backend/schemas/stat_schema.py
+++ b/backend/schemas/stat_schema.py
@@ -1,0 +1,55 @@
+'''
+Gift Demand 결과를 반환하기 위한 Pydantic 스키마 정의 파일.
+
+- GiftDemandOut: 전체 요약(summary) API에서 사용
+- PriorityTop3: priority별 Top3에서 사용
+- PriorityGroupOut: priority1/priority2/priority3 묶음 반환
+'''
+
+from pydantic import BaseModel, ConfigDict
+from typing import List
+
+# ==============================
+# 1) 기존 summary용 스키마 유지
+# ==============================
+class GiftDemandOut(BaseModel):
+    '''
+    선물(GiftID)별 총 수요량 Summary 응답 스키마.
+
+    Attributes:
+        gift_id (int): Finished_Goods.gift_id
+        count (int): 해당 Gift를 원하는 총 아이 수
+        p1/p2/p3: 우선순위별 수요량 (summary 용)
+    '''
+    gift_id: int
+    count: int
+    p1: int
+    p2: int
+    p3: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ==============================
+# 2) priority별 Top3용 스키마
+# ==============================
+class PriorityTop3(BaseModel):
+    '''
+    우선순위(Priority)별 Top3 항목.
+    '''
+    gift_id: int
+    gift_name: str
+    count: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PriorityGroupOut(BaseModel):
+    '''
+    priority1, priority2, priority3 각각의 Top3를 묶어 반환하는 스키마
+    '''
+    priority1: List[PriorityTop3]
+    priority2: List[PriorityTop3]
+    priority3: List[PriorityTop3]
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## 요약 (Summary)
이번 PR에서는 ListElf의 Gift Demand 집계 API에  
**우선순위(priority) 기반 집계 및 정렬 기능을 추가**했습니다.

착한(NICE) 상태이며 아직 선물을 받지 않은(NOT DELIVERED) 아이들을 기준으로  
Wishlist를 집계하여, Santa 생산팀이 어떤 선물을 먼저 준비해야 할지  
더 명확하게 판단할 수 있도록 기능을 개선했습니다.

---

## 주요 변경 사항 (What's Changed)

### Gift Demand 집계 로직 개선
- NICE + NOT DELIVERED 조건으로 Child 필터링
- Wishlist를 GiftID 기준으로 그룹화하여 수요량 집계
- Priority별 요청 수(`p1`, `p2`, `p3`) 계산 추가
- 총 수요량(`count`) 계산 추가

### 우선순위 기반 정렬 규칙 적용
정렬 기준은 다음 우선순위를 따릅니다:

1. Priority 1 요청 수 (`p1` DESC)
2. Priority 2 요청 수 (`p2` DESC)
3. Priority 3 요청 수 (`p3` DESC)
4. 총 수요량 (`count` DESC)

이를 통해 “가장 우선적으로 생산해야 하는 선물”을 가장 먼저 확인 가능.

### 응답 스키마 확장 (`GiftDemandOut`)
- 기존 `count` 중심 스키마에서  
  `p1`, `p2`, `p3`, `count` 포함한 확장 스키마로 변경
- 실제 운영/생산팀 요구사항 반영

### StatusCode 비교 시 발생하던 대소문자 문제 해결
- SQLAlchemy `func.upper()` 기반 비교로 문제 해결
- swagger 입력이 소문자/대문자 혼합이어도 정상 작동

### Swagger 테스트 편의성 강화
- 반복 테스트를 위한 더미 Child/Wishlist JSON 데이터 제공
- NICE + PENDING 조합 확인 용이

---

## 핵심 기능 (Key Features)

### NICE + NOT DELIVERED Child만 집계
Santa의 실제 업무 플로우에 맞춘 필터링 로직.

### Priority 기반 집계 제공
- 우선선호도(p1 -> p2 -> p3)를 기반으로 선물 수요 판단 가능
- 전체 수요량(count)도 함께 제공

### 우선순위 중심 정렬 결과
생산팀이 어떤 선물을 먼저 준비해야 할지 직관적으로 확인 가능.

### 확장 가능 구조
GiftID 외에도 Region별, AgeGroup별 수요 통계 등  
추가 통계 기능을 쉽게 확장할 수 있는 구조 유지.

---

## 테스트 체크리스트

- [x] NICE + NOT DELIVERED 필터링 정상 동작  
- [x] Wishlist p1/p2/p3 집계 정확  
- [x] GiftID 기준 group by 정상  
- [x] 우선순위 기반 정렬 규칙(p1→p2→p3→count) 정확  
- [x] wishlist 없는 Child 자동 제외  
- [x] 응답 스키마 정상  
- [x] Swagger UI 호출 문제 없음  

---