### PR TITLE
#ISSUE25 - [FEAT] - Child 전체 조회 API 및 ChildNote 단독 조회 API 추가

### DIFF
--- a/backend/schemas/child_schema.py
+++ b/backend/schemas/child_schema.py
@@ -2,10 +2,15 @@
 클라이언트가 보내는 JSON 형식을 검증하는 스키마
 
 (주요 기능)
-- Child 생성 스키마(ChildCreate)
-- Child 수정 스키마(ChildUpdate)
-- Wishlist CRUD 스키마(WishlistCreate, WishlistUpdate)
-- Child + Wishlist 묶음 출력 스키마(ChildOut, ChildDetailOut)
+WishlistItem            - ChildCreate 입력용 단일 wishlist 아이템
+ChildCreate             - Child + Wishlist 여러 개를 한 번에 생성할 때 사용
+ChildUpdate             - Child 정보 수정 (PATCH)
+WishlistCreate/Update   - wishlist 개별 CRUD
+WishlistItemOut         - 서버가 반환하는 wishlist 아이템
+ChildOut                - 생성/수정 응답 구조
+ChildDetailOut          - 단일 Child 상세 조회용
+ChildFullOut            - 전체 Child 리스트 조회용
+ChildNoteOut            - child_note만 반환하는 스키마
 '''
 
 from typing import List
@@ -133,5 +138,26 @@ class ChildDetailOut(BaseModel):
     delivery_status_code: str
     child_note: Optional[str] = None
     wishlist: List[WishlistItemOut]
+
+    model_config = ConfigDict(from_attributes=True)
+
+# 전체 Child 리스트 조회용 스키마
+class ChildFullOut(BaseModel):
+    child_id: int
+    name: str
+    address: str
+    region_id: int
+    status_code: str
+    delivery_status_code: str
+    child_note: Optional[str]
+    wishlist: List[WishlistItemOut]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# child_note만 반환하는 스키마
+class ChildNoteOut(BaseModel):
+    child_id: int
+    child_note: Optional[str]
 
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## 개요
ListElf 서비스에서 Child 데이터를 다양한 화면에서 활용하기 위해  
조회 기능을 확장하고 구조를 명확하게 정리하는 PR입니다.

기존에는 Child 상세 조회(/details)는 존재했지만,  
전체 리스트 조회나 child_note만 조회하는 기능이 없어서  
UI 개발 및 작업 흐름에 불편함이 있었습니다.

이를 해결하기 위해 다음 기능을 추가/정비했습니다.

---

## 주요 변경 사항

### Child 전체 조회 API 추가 
**GET /list-elf/child/all**
- 모든 Child를 한 번에 조회하는 API 추가
- 상태(StatusCode), 배송상태, child_note 포함
- 각 Child의 wishlist를 함께 반환
- 메인 화면에서 전체 목록을 조회할 때 사용

---

### ChildNote 단독 조회 API 추가 
**GET /list-elf/child/{child_id}/note**
- ChildNote(설명)만 따로 반환하는 전용 API
- 상세 페이지에서 Description 부분만 Lazy Loading 시 유용

---

## 스키마 추가
- `ChildFullOut`: 전체 조회용 스키마 (신규)
- `ChildNoteOut`: child_note 단독 조회용 스키마 (신규)

---

## 테스트 체크리스트
- [x] /all 정상 반환 (Child + Wishlist)
- [x] /{id}/note 정상 반환 (child_note만)
- [x] 기존 /details와 충돌 없음
- [x] 없는 ID 조회 시 404 처리 정상
- [x] 대소문자 불일치 문제 없음

---

##  결론
조회 기능이 확장되며 ListElf의 리스트 화면과 상세 화면 개발이 훨씬 유연해졌습니다.  
다음 단계에서 검색/필터 기능도 자연스럽게 확장할 수 있습니다.
