### PR TITLE
#ISSUE35 - [FEAT] - ListElf 아이 관리 화면 + 지역 필터 + Wishlist 상세 API 구현

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -33,7 +33,7 @@ from backend.routers import (gift, production, reindeer,
                              list_elf_child, child_status_code, 
                              delivery_status_code,list_elf_stats,
                              staff, list_elf_rules, santa_view,
-                             santa, delivery_log)
+                             santa, delivery_log, region)
 app.include_router(gift.router)
 app.include_router(production.router)
 app.include_router(reindeer.router)
@@ -46,6 +46,7 @@ app.include_router(delivery_log.router)
 app.include_router(staff.router)
 app.include_router(list_elf_rules.router)
 app.include_router(santa_view.router)
+app.include_router(region.router)
 
 from fastapi.staticfiles import StaticFiles
 app.mount("/", StaticFiles(directory="frontend", html=True), name="frontend")

--- a/backend/routers/region.py
+++ b/backend/routers/region.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from backend.database import get_db
+from backend.models.region import Region
+
+router = APIRouter(prefix="/regions", tags=["Regions"])
+
+@router.get("/all")
+def get_all_regions(db: Session = Depends(get_db)):
+    regions = db.query(Region).all()
+    return [
+        {
+            "RegionID": r.RegionID,
+            "RegionName": r.RegionName
+        }
+        for r in regions
+    ]

--- a/frontend/list_elf.html
+++ b/frontend/list_elf.html
@@ -1,21 +1,311 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>ListElf - 아이 목록</title>
 
-    <!-- Bootstrap -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"/>
+
+    <style>
+        body { background-color: #f7f9f7; }
+        .priority-1 { background: #fff3cd; }
+        .priority-2 { background: #e2e3e5; }
+        .priority-3 { background: #d4edda; }
+    </style>
 </head>
 
 <body>
 
 <div class="container py-4">
-    <h2 class="mb-4">🧝‍♂️ ListElf - 아이 목록</h2>
 
-    <p class="text-muted">여기에 아이 목록 테이블, 검색, 상태 수정, Note 수정 등이 들어갑니다.</p>
+    <h2 class="mb-4 fw-bold">🎄 ListElf – 아이 목록</h2>
+
+    <!-- 검색 + 지역 필터 -->
+    <div class="row mb-3">
+        <div class="col-6">
+            <input id="searchInput" class="form-control" placeholder="이름 또는 주소 검색…" />
+        </div>
+        <div class="col-3">
+            <select id="regionFilter" class="form-select" onchange="renderChildren()">
+                <option value="">전체 지역</option>
+            </select>
+        </div>
+        <div class="col-3">
+            <button class="btn btn-secondary w-100" onclick="loadChildren()">검색</button>
+        </div>
+    </div>
+
+    <!-- 요약 패널 -->
+    <div class="row mb-4">
+        <div class="col">
+            <div class="p-3 bg-light border rounded">착한 아이: <span id="countNice">0</span></div>
+        </div>
+        <div class="col">
+            <div class="p-3 bg-light border rounded">나쁜 아이: <span id="countNaughty">0</span></div>
+        </div>
+        <div class="col">
+            <div class="p-3 bg-light border rounded">심사 대기: <span id="countPending">0</span></div>
+        </div>
+    </div>
+
+    <!-- 아이 테이블 -->
+    <table class="table table-hover align-middle">
+        <thead class="table-secondary">
+            <tr>
+                <th>ID</th>
+                <th>이름</th>
+                <th>주소</th>
+                <th>지역</th>
+                <th>상태</th>
+                <th>배송 상태</th>
+                <th>Wishlist</th>
+                <th>설명</th>
+                <th>작업</th>
+            </tr>
+        </thead>
+        <tbody id="childTableBody"></tbody>
+    </table>
+
 </div>
+
+<!-- 🎁 Wishlist 모달 -->
+<div class="modal fade" id="wishlistModal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+
+            <div class="modal-header">
+                <h5 class="modal-title">Wishlist 상세보기</h5>
+                <button class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+
+            <div class="modal-body">
+                <table class="table table-bordered">
+                    <thead class="table-light">
+                        <tr>
+                            <th>우선순위</th>
+                            <th>Gift ID</th>
+                            <th>비고</th>
+                        </tr>
+                    </thead>
+                    <tbody id="wishlistTableBody"></tbody>
+                </table>
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<!-- 📝 Note 수정 모달 -->
+<div class="modal fade" id="noteModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+
+            <div class="modal-header">
+                <h5 class="modal-title">아이 설명 수정</h5>
+                <button class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+
+            <div class="modal-body">
+                <textarea id="noteInput" class="form-control" rows="6"></textarea>
+            </div>
+
+            <div class="modal-footer">
+                <button class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                <button class="btn btn-primary" onclick="saveNote()">저장</button>
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+
+<script>
+const BASE_URL = "http://127.0.0.1:8000";
+
+let childrenData = [];
+let regions = [];
+let currentEditChildId = null;
+
+/* -------------------------
+   Region 불러오기
+------------------------- */
+async function loadRegions() {
+    const res = await fetch(`${BASE_URL}/regions/all`);
+    regions = await res.json();
+
+    const filter = document.getElementById("regionFilter");
+    regions.forEach(r => {
+        filter.innerHTML += `<option value="${r.RegionID}">${r.RegionName}</option>`;
+    });
+}
+
+/* -------------------------
+   Child 목록 불러오기
+------------------------- */
+async function loadChildren() {
+    const res = await fetch(`${BASE_URL}/list-elf/child/all`);
+    childrenData = await res.json();
+    renderChildren();
+}
+
+/* -------------------------
+   Child 테이블 렌더링
+------------------------- */
+function renderChildren() {
+    const keyword = document.getElementById("searchInput").value.trim();
+    const regionValue = document.getElementById("regionFilter").value;
+
+    const tbody = document.getElementById("childTableBody");
+    tbody.innerHTML = "";
+
+    let nice=0, naughty=0, pending=0;
+
+    childrenData
+        .filter(c => (!keyword || c.name.includes(keyword) || c.address.includes(keyword)))
+        .filter(c => (!regionValue || c.region_id == regionValue))
+        .forEach(c => {
+
+            if (c.status_code === "NICE") nice++;
+            else if (c.status_code === "NAUGHTY") naughty++;
+            else pending++;
+
+            const regionName = (regions.find(r => r.RegionID == c.region_id) || {}).RegionName || "(미지정)";
+
+            tbody.innerHTML += `
+                <tr>
+                    <td>${c.child_id}</td>
+                    <td>${c.name}</td>
+                    <td>${c.address}</td>
+                    <td>${regionName}</td>
+
+                    <td>
+                        <select class="form-select form-select-sm"
+                                onchange="updateStatus(${c.child_id}, this.value)">
+                            <option value="PENDING" ${c.status_code==="PENDING"?"selected":""}>PENDING</option>
+                            <option value="NICE" ${c.status_code==="NICE"?"selected":""}>NICE</option>
+                            <option value="NAUGHTY" ${c.status_code==="NAUGHTY"?"selected":""}>NAUGHTY</option>
+                        </select>
+                    </td>
+
+                    <td>
+                        <span class="badge bg-${c.delivery_status_code === "DELIVERED" ? "primary" : "secondary"}">
+                            ${c.delivery_status_code}
+                        </span>
+                    </td>
+
+                    <td>
+                        <button class="btn btn-info btn-sm" onclick="openWishlistModal('${c.child_id}')">
+                            🎁 보기
+                        </button>
+                    </td>
+
+                    <td>
+                        <button class="btn btn-outline-secondary btn-sm" onclick="openNoteModal(${c.child_id})">
+                            보기/수정
+                        </button>
+                    </td>
+
+                    <td>
+                        <button class="btn btn-danger btn-sm" onclick="deleteChild(${c.child_id})">삭제</button>
+                    </td>
+                </tr>
+            `;
+        });
+
+    document.getElementById("countNice").innerText = nice;
+    document.getElementById("countNaughty").innerText = naughty;
+    document.getElementById("countPending").innerText = pending;
+}
+
+/* -------------------------
+   🎁 Wishlist 모달
+   → /list-elf/child/{id}/details 사용
+------------------------- */
+async function openWishlistModal(childId) {
+    const res = await fetch(`${BASE_URL}/list-elf/child/${childId}/wishlist`);
+    const data = await res.json();
+
+    const tbody = document.getElementById("wishlistTableBody");
+    tbody.innerHTML = "";
+
+    data.wishlist.forEach(item => {
+        tbody.innerHTML += `
+            <tr class="priority-${item.priority}">
+                <td>${item.priority}</td>
+                <td>${item.gift_id}</td>
+                <td>${item.gift_name}</td>
+            </tr>
+        `;
+    });
+
+    new bootstrap.Modal(document.getElementById("wishlistModal")).show();
+}
+
+
+/* -------------------------
+   📝 Note 모달
+------------------------- */
+function openNoteModal(childId) {
+    currentEditChildId = childId;
+
+    const child = childrenData.find(c => c.child_id === childId);
+    document.getElementById("noteInput").value = child.child_note || "";
+
+    new bootstrap.Modal(document.getElementById("noteModal")).show();
+}
+
+/* -------------------------
+   Note 저장
+------------------------- */
+async function saveNote() {
+    const note = document.getElementById("noteInput").value;
+
+    await fetch(`${BASE_URL}/list-elf/child/${currentEditChildId}`, {
+        method: "PATCH",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({ child_note: note })
+    });
+
+    loadChildren();
+    bootstrap.Modal.getInstance(document.getElementById("noteModal")).hide();
+}
+
+/* -------------------------
+   Child 삭제
+------------------------- */
+async function deleteChild(childId) {
+    if (!confirm("정말 삭제하시겠습니까?")) return;
+
+    await fetch(`${BASE_URL}/list-elf/child/${childId}`, {
+        method: "DELETE"
+    });
+
+    loadChildren();
+}
+
+/* -------------------------
+   상태 변경
+------------------------- */
+async function updateStatus(childId, newStatus) {
+    await fetch(`${BASE_URL}/list-elf/child/${childId}`, {
+        method: "PATCH",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({ status_code: newStatus })
+    });
+
+    loadChildren();
+}
+
+/* -------------------------
+   초기 실행
+------------------------- */
+(async function init() {
+    await loadRegions();
+    await loadChildren();
+})();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## 요약

ListElf의 아이 관리 화면을 구축하고  
지역 필터 기능을 추가하였으며  
Wishlist 상세 조회용 API를 신규 구현했습니다.

---

## 주요 변경 사항

### 1) ListElf 아이 목록 화면 (`frontend/list_elf.html`)

- 이름/주소 텍스트 검색
- **지역 필터 추가**
  - `/regions/all` 로 Region 목록 로드
  - RegionID → RegionName 변환
  - '전체 지역' 포함한 필터 옵션 생성
- 요약 패널
  - NICE / NAUGHTY / PENDING 카운트
- 아이 목록 테이블
  - 지역명 표시
  - 상태(StatusCode) 드롭다운 변경 기능
  - 배송 상태 Badge 표시
  - Wishlist 보기 버튼
  - 설명 보기/수정 버튼
  - 삭제 버튼

---

### 2) Wishlist 상세 모달

- `/list-elf/child/{child_id}/wishlist` 호출
- 우선순위, GiftID, GiftName 표시
- 우선순위별 배경색 적용

---

### 3) Wishlist 조회 전용 API 추가

#### 신규 경로
`GET /list-elf/child/{child_id}/wishlist`

#### 처리 내용
- Child 존재 여부 확인
- Wishlist + FinishedGoods JOIN
- GiftName 포함한 결과 반환
- Priority ASC 정렬

---

## 관련 파일

- `frontend/list_elf.html`
- `backend/routers/list_elf_child.py`

---

## 테스트

- [x] 지역 목록 정상 로드 및 필터링 동작
- [x] 지역명 테이블 표시 정상
- [x] 상태/노트 수정 정상 동작
- [x] Child 삭제 정상
- [x] Wishlist 모달 정상 표시
- [x] `/list-elf/child/{child_id}/wishlist` 200 OK 확인
