### PR TITLE
#ISSUE42 - FEAT - Rules 페이지 생성 + 단순 login.html 파일 추

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+    <h1>로그인 페이지 구현 예정 ...</h1>
+</body>
+</html>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ListElf - 규칙 관리</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+
+  <style>
+    :root {
+      --scdms-red: #d64840;
+      --scdms-red-dark: #b73530;
+      --scdms-bg: #f9fbf7;
+    }
+
+    body {
+      background: radial-gradient(circle at top, #ffe7e0 0, #f9fbf7 45%, #f4f7f4 100%);
+      min-height: 100vh;
+    }
+
+    /* 상단 네비게이션 */
+    .scdms-navbar {
+      background: var(--scdms-red);
+    }
+    .scdms-navbar .navbar-brand {
+      font-weight: 700;
+    }
+    .scdms-navbar .brand-icon {
+      margin-right: 6px;
+    }
+
+    /* 상단 탭 네비게이션 */
+    .scdms-tabs {
+      background: #fff5f3;
+      border-bottom: 1px solid #f0d2cd;
+    }
+    .scdms-tabs .nav-link {
+      border-radius: 999px;
+      padding: 8px 20px;
+      margin-right: 8px;
+      font-weight: 600;
+      color: #555;
+    }
+    .scdms-tabs .nav-link.active {
+      background: var(--scdms-red);
+      color: #fff;
+    }
+
+    /* 메인 카드 */
+    .scdms-card {
+      background: #ffffff;
+      border-radius: 18px;
+      border: 1px solid #f0f0f0;
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.04);
+    }
+
+    .section-title {
+      font-weight: 700;
+      font-size: 1.1rem;
+    }
+
+    .rule-row-title {
+      font-weight: 600;
+    }
+
+    .text-meta {
+      font-size: 0.8rem;
+      color: #888;
+    }
+
+    .btn-main {
+      background: var(--scdms-red);
+      border-color: var(--scdms-red);
+    }
+    .btn-main:hover {
+      background: var(--scdms-red-dark);
+      border-color: var(--scdms-red-dark);
+    }
+
+    .rules-empty {
+      text-align: center;
+      padding: 24px 0;
+      color: #999;
+      font-size: 0.95rem;
+    }
+  </style>
+</head>
+
+<body>
+<!-- 상단 글로벌 네비게이션 -->
+<nav class="navbar navbar-expand-lg navbar-dark scdms-navbar">
+  <div class="container-fluid px-4">
+    <a class="navbar-brand d-flex align-items-center" href="#">
+      <span class="brand-icon">🎄</span>
+      <span>SCDMS · 명단 관리 요청 제어센터</span>
+    </a>
+    <div class="d-flex align-items-center">
+      <span class="badge bg-light text-dark me-3">ListElf</span>
+      <a href="/login.html" class="btn btn-outline-light btn-sm">로그아웃</a>
+    </div>
+  </div>
+</nav>
+
+<!-- 상단 탭 -->
+<div class="scdms-tabs">
+  <div class="container px-4">
+    <ul class="nav py-3">
+      <li class="nav-item">
+        <a class="nav-link" href="/list_elf.html">아이 목록</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/add_child.html">아이 등록</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" href="/rules.html">규칙 관리</a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<!-- 메인 콘텐츠 -->
+<div class="container px-4 py-4">
+  <div class="scdms-card p-4 p-md-5">
+
+    <!-- 타이틀 -->
+    <div class="mb-4">
+      <h2 class="fw-bold mb-1">규칙 관리</h2>
+      <p class="text-muted mb-0">
+        아이를 착한/나쁜 아이로 분류할 때 참고하는 기준 문구를 관리합니다. (운영 참고용)
+      </p>
+    </div>
+
+    <!-- 1. 새 규칙 만들기 -->
+    <div class="mb-4">
+      <div class="section-title mb-2">➕ 새 규칙 만들기</div>
+      <p class="text-muted mb-3 small">제목과 상세 기준을 입력하고 규칙을 추가하세요.</p>
+
+      <div class="mb-3">
+        <label class="form-label">규칙 제목 *</label>
+        <input id="ruleTitle" class="form-control" placeholder="예: 편식 안함이" />
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">규칙 상세 기준 *</label>
+        <textarea id="ruleDescription" class="form-control" rows="3"
+                  placeholder="예: 최근 한 달간 야채를 엄청 많이 먹음"></textarea>
+      </div>
+
+      <div class="text-end">
+        <button class="btn btn-main" onclick="createRule()">+ 규칙 추가</button>
+      </div>
+    </div>
+
+    <hr class="my-4" />
+
+    <!-- 2. 활성 규칙 목록 -->
+    <div>
+      <div class="section-title mb-2">📖 활성 규칙</div>
+      <p class="text-muted mb-3 small">현재 운영 중인 분류 기준들입니다.</p>
+
+      <div id="rulesContainer">
+        <!-- 규칙 리스트 렌더링 영역 -->
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- 📄 규칙 상세보기 모달 -->
+<div class="modal fade" id="ruleDetailModal" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+
+      <div class="modal-header">
+        <h5 class="modal-title">규칙 상세보기</h5>
+        <button class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+
+      <div class="modal-body">
+        <h5 id="detailTitle" class="fw-bold mb-2"></h5>
+        <p class="text-meta mb-3" id="detailMeta"></p>
+
+        <div class="mb-2 fw-semibold">상세 설명</div>
+        <pre id="detailDescription"
+             style="white-space: pre-wrap; font-family: inherit; font-size: 0.95rem;"></pre>
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn btn-outline-secondary" data-bs-dismiss="modal">닫기</button>
+        <button class="btn btn-main" onclick="openEditModal()">수정하기</button>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!-- ✏ 규칙 수정 모달 -->
+<div class="modal fade" id="ruleEditModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <div class="modal-header">
+        <h5 class="modal-title">규칙 수정</h5>
+        <button class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label">규칙 제목</label>
+          <input id="editTitle" class="form-control" />
+        </div>
+        <div class="mb-3">
+          <label class="form-label">규칙 상세 기준</label>
+          <textarea id="editDescription" class="form-control" rows="4"></textarea>
+        </div>
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
+        <button class="btn btn-main" onclick="saveRuleEdit()">저장</button>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+
+<script>
+  const BASE_URL = "http://127.0.0.1:8000";
+
+  let rules = [];
+  let currentRuleId = null; // 상세보기 / 수정 대상 rule_id
+
+  /* Staff ID 가져오기 (로그인 연동되면 여기만 맞추면 됨) */
+  /*⭐⭐⭐⭐⭐⭐⭐⭐⭐수정⭐⭐⭐⭐⭐⭐⭐⭐*/
+  function getStaffId() {
+    const stored = localStorage.getItem("staff_id");
+    if (stored) return parseInt(stored);
+    // 임시: 로그인 연동 전이면 1로 고정
+    return 1;
+  }
+   /*⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐*/
+
+  /* 규칙 생성 */
+  async function createRule() {
+    const title = document.getElementById("ruleTitle").value.trim();
+    const description = document.getElementById("ruleDescription").value.trim();
+    const staffId = getStaffId();
+
+    if (!title || !description) {
+      alert("규칙 제목과 상세 기준을 모두 입력해주세요.");
+      return;
+    }
+
+    const body = {
+      title,
+      description,
+      created_by_staff_id: staffId
+    };
+
+    try {
+      const res = await fetch(`${BASE_URL}/list-elf/rules/create`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert("규칙 생성에 실패했습니다.\n" + (err.detail || ""));
+        return;
+      }
+
+      document.getElementById("ruleTitle").value = "";
+      document.getElementById("ruleDescription").value = "";
+      await loadRules();
+    } catch (e) {
+      console.error(e);
+      alert("서버와 통신 중 오류가 발생했습니다.");
+    }
+  }
+
+  /* 📥 규칙 전체 조회 */
+  async function loadRules() {
+    try {
+      const res = await fetch(`${BASE_URL}/list-elf/rules/all`);
+      rules = await res.json();
+      renderRules();
+    } catch (e) {
+      console.error(e);
+      alert("규칙 목록을 불러오는 중 오류가 발생했습니다.");
+    }
+  }
+
+  /* 🖼 규칙 리스트 렌더링 */
+  function renderRules() {
+    const container = document.getElementById("rulesContainer");
+    container.innerHTML = "";
+
+    if (!rules || rules.length === 0) {
+      container.innerHTML = `<div class="rules-empty">등록된 규칙이 없습니다. 위에서 새 규칙을 추가해 주세요.</div>`;
+      return;
+    }
+
+    const table = document.createElement("table");
+    table.className = "table align-middle mb-0";
+
+    const thead = document.createElement("thead");
+    thead.innerHTML = `
+      <tr class="table-secondary">
+        <th style="width: 70px;">ID</th>
+        <th>제목</th>
+        <th style="width: 130px;">작성자</th>
+        <th style="width: 170px;">생성일</th>
+        <th style="width: 180px;">규칙 내용</th>
+      </tr>
+    `;
+
+    const tbody = document.createElement("tbody");
+
+    rules.forEach(rule => {
+      const tr = document.createElement("tr");
+
+      const createdAt = formatDate(rule.created_at);
+
+      tr.innerHTML = `
+        <td>${rule.rule_id}</td>
+        <td class="rule-row-title">${escapeHtml(rule.title)}</td>
+        <td>${rule.created_by_staff_id}</td>
+        <td>${createdAt}</td>
+        <td>
+          <button class="btn btn-sm btn-outline-primary me-1"
+                  onclick="openRuleDetail(${rule.rule_id})">
+            상세보기
+          </button>
+          <button class="btn btn-sm btn-outline-danger"
+                  onclick="deleteRule(${rule.rule_id})">
+            🗑
+          </button>
+        </td>
+      `;
+
+      tbody.appendChild(tr);
+    });
+
+    table.appendChild(thead);
+    table.appendChild(tbody);
+    container.appendChild(table);
+  }
+
+  /* 📄 규칙 상세 보기 모달 열기 */
+  function openRuleDetail(ruleId) {
+    const rule = rules.find(r => r.rule_id === ruleId);
+    if (!rule) return;
+
+    currentRuleId = ruleId;
+
+    const titleEl = document.getElementById("detailTitle");
+    const metaEl = document.getElementById("detailMeta");
+    const descEl = document.getElementById("detailDescription");
+
+    titleEl.textContent = rule.title;
+
+    const createdAt = formatDate(rule.created_at);
+    const updatedAt = formatDate(rule.updated_at);
+
+    let meta = `작성자: #${rule.created_by_staff_id} · 생성: ${createdAt}`;
+    if (rule.updated_by_staff_id) {
+      meta += `\n수정자: #${rule.updated_by_staff_id} · 수정: ${updatedAt}`;
+    } else {
+      meta += `\n수정 기록 없음`;
+    }
+    metaEl.textContent = meta;
+
+    descEl.textContent = rule.description || "";
+
+    const modalEl = document.getElementById("ruleDetailModal");
+    const modal = new bootstrap.Modal(modalEl);
+    modal.show();
+  }
+
+  /* ✏ 상세보기에서 수정 모달 열기 */
+  function openEditModal() {
+    const rule = rules.find(r => r.rule_id === currentRuleId);
+    if (!rule) return;
+
+    document.getElementById("editTitle").value = rule.title;
+    document.getElementById("editDescription").value = rule.description;
+
+    const detailModalEl = document.getElementById("ruleDetailModal");
+    const detailModal = bootstrap.Modal.getInstance(detailModalEl);
+    if (detailModal) detailModal.hide();
+
+    const editModalEl = document.getElementById("ruleEditModal");
+    const editModal = new bootstrap.Modal(editModalEl);
+    editModal.show();
+  }
+
+  /* 💾 규칙 수정 저장 */
+  async function saveRuleEdit() {
+    const title = document.getElementById("editTitle").value.trim();
+    const description = document.getElementById("editDescription").value.trim();
+    const staffId = getStaffId();
+
+    if (!title || !description) {
+      alert("규칙 제목과 상세 기준을 모두 입력해주세요.");
+      return;
+    }
+
+    const body = {
+      title,
+      description,
+      updated_by_staff_id: staffId
+    };
+
+    try {
+      const res = await fetch(`${BASE_URL}/list-elf/rules/update/${currentRuleId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert("규칙 수정에 실패했습니다.\n" + (err.detail || ""));
+        return;
+      }
+
+      const editModalEl = document.getElementById("ruleEditModal");
+      const editModal = bootstrap.Modal.getInstance(editModalEl);
+      if (editModal) editModal.hide();
+
+      await loadRules();
+    } catch (e) {
+      console.error(e);
+      alert("서버와 통신 중 오류가 발생했습니다.");
+    }
+  }
+
+  /* 🗑 규칙 삭제 */
+  async function deleteRule(ruleId) {
+    if (!confirm("해당 규칙을 삭제하시겠습니까?")) return;
+
+    try {
+      const res = await fetch(`${BASE_URL}/list-elf/rules/${ruleId}`, {
+        method: "DELETE"
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert("규칙 삭제에 실패했습니다.\n" + (err.detail || ""));
+        return;
+      }
+
+      await loadRules();
+    } catch (e) {
+      console.error(e);
+      alert("서버와 통신 중 오류가 발생했습니다.");
+    }
+  }
+
+  /* 유틸: 날짜 포맷 */
+  function formatDate(value) {
+    if (!value) return "-";
+    const d = new Date(value);
+    if (isNaN(d.getTime())) return value;
+    return d.toLocaleString("ko-KR");
+  }
+
+  /* 유틸: XSS 방지용 간단 escape */
+  function escapeHtml(str) {
+    if (str == null) return "";
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  /* 초기 실행 */
+  (async function init() {
+    await loadRules();
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## 요약
이번 PR은 ListElf 역할에서 규칙을 관리할 수 있도록 하는 **신규 규칙 페이지(rules.html)** 전체를 구현한 작업입니다.  
이번 기능에서는 규칙 생성(Create), 조회(Read), 상세 보기(Modal), 수정(Update), 삭제(Delete)이 모두 가능하며,  
UI는 기존 페이지(add_child / list_elf)와 동일한 산타 테마 기반 디자인으로 통일하였습니다.

---

## 주요 구현 사항

### 새로운 규칙 관리 페이지 생성 (`rules.html`)
- 상단 네비게이션 + 탭 구조 적용 (기존 UI와 완전 통일)
- “새 규칙 만들기” 섹션 추가  
  - 규칙 제목(title) 입력  
  - 규칙 상세 설명(description) 입력  
  - created_by_staff_id 포함하여 규칙 생성 요청  
- 규칙 리스트 테이블 렌더링  
  - Rule ID / 제목 / 작성자 / 생성일 / 작업 버튼 표시  
  - 기존 페이지들과 동일한 스타일의 카드형 디자인 적용

---

### 규칙 상세보기 모달
- 제목, 상세 설명(줄바꿈 보존), 생성자/수정자 정보, 생성/수정 날짜 모두 표시
- 리스트에서 긴 설명이 노출되지 않도록 UX 최적화  
- “수정하기” 버튼 클릭 시 수정 모달로 이동하는 구조

---

### 규칙 수정 모달 
- 제목/설명 수정 가능  
- updated_by_staff_id 자동 전송  
- 수정 성공 후 리스트 자동 갱신  
- 기존 수정 방식보다 더 안전하고 명확한 흐름 제공

---

### 규칙 삭제 기능
- 삭제 버튼 클릭 -> Confirm -> 삭제  
- 성공 시 즉시 리스트 재렌더링  
- API: `DELETE /list-elf/rules/{rule_id}`

---

###  백엔드 API 스펙 완전 대응 (rule_schema.py / rules.py 기반)
- RuleCreate → 생성 시 사용  
- RuleUpdate → 수정 시 사용  
- RuleOut → 리스트/상세조회 시 사용  
- created_by / updated_by / created_at / updated_at 전부 정상 표시됨

---

## UI/UX 개선 사항
- 기존 add_child / list_elf 페이지와 동일한 테마 적용  
- 배경 그라데이션, 둥근 카드 레이아웃, 버튼 스타일 통일  
- 리스트는 핵심 정보만 보여주고 상세는 모달에서 확인하는 구조로 가독성 향상  
- 테이블 너비/간격 최적화 → 긴 텍스트에도 UI 깨지지 않음  

---

## 테스트 항목 (Checklist)
- [ ] 규칙 생성이 정상적으로 DB에 저장되는지  
- [ ] 규칙 리스트가 문제없이 렌더링되는지  
- [ ] 상세보기 모달(Detail Modal)에 정보가 정확히 표시되는지  
- [ ] 수정 모달(Edit Modal)에서 제목/설명 수정이 정상 반영되는지  
- [ ] updated_by_staff_id가 정상 반영되는지  
- [ ] 삭제 기능 정상 동작하는지  
- [ ] UI가 다른 페이지들과 통일된 스타일인지  

---

## 이번 PR의 목적 

- ListElf가 아이 분류 시 참고할 기준 문구를 체계적으로 관리할 수 있도록 기능 제공  
- 규칙을 작성/수정한 사람과 시점을 기록하여 데이터 신뢰성 확보  
- 전체 FE UI 통일로 사용자 경험 개선  
- 산타 테마 기반 프로젝트 완성도 향상  

