### PR TITLE
#ISSUE47 - [FEAT] - Keeper용 루돌프 관리 페이지 UI 구현

### DIFF
--- a/frontend/css/reindeer.css
+++ b/frontend/css/reindeer.css
@@ -1,0 +1,150 @@
+/* 전반적인 배경/폰트 */
+body {
+    background-color: #fdfbf7; /* 약간 더 따뜻한 색감 */
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  
+  /* 헤더: 루돌프 관리자는 갈색 계열 */
+  .app-header {
+    background: linear-gradient(90deg, #8B4513, #5D4037);
+  }
+  
+  /* 탭 패널 보이기/숨기기 */
+  .tab-panel {
+    display: none;
+  }
+  .tab-panel.active {
+    display: block;
+    animation: fadeIn 0.3s ease-in-out;
+  }
+  
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(5px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  
+  /* 네비게이션 탭 커스텀 */
+  .nav-pills .nav-link {
+    color: #5d4037;
+    background-color: transparent;
+    border: 1px solid transparent;
+  }
+  .nav-pills .nav-link.active {
+    background-color: #8B4513;
+    color: white;
+  }
+  
+  /* 루돌프 카드 스타일 */
+  .reindeer-card {
+    border-radius: 0.75rem;
+    background: #ffffff;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    padding: 1.25rem;
+    height: 100%;
+    transition: transform 0.2s;
+  }
+  .reindeer-card:hover {
+    transform: translateY(-2px);
+  }
+  
+  .card-header-custom {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid #f0f0f0;
+  }
+  
+  .reindeer-name {
+    font-weight: 700;
+    font-size: 1.15rem;
+    color: #3e2723;
+  }
+  
+  /* 상태 뱃지 */
+  .status-badge {
+    padding: 0.35em 0.8em;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+  .status-READY { background-color: #E8F5E9; color: #2E7D32; border: 1px solid #C8E6C9; }
+  .status-RESTING { background-color: #FFF3E0; color: #EF6C00; border: 1px solid #FFE0B2; }
+  .status-ONDELIVERY { background-color: #E3F2FD; color: #1565C0; border: 1px solid #BBDEFB; }
+  
+  /* 프로그레스 바 영역 */
+  .stat-row {
+    margin-bottom: 0.8rem;
+  }
+  .stat-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #555;
+    margin-bottom: 0.3rem;
+  }
+  
+  .progress-custom {
+    height: 8px;
+    border-radius: 999px;
+    background-color: #eceff1;
+    overflow: hidden;
+  }
+  
+  .progress-bar-stamina { background-color: #d32f2f; } /* 빨강 */
+  .progress-bar-magic { background-color: #1976d2; }   /* 파랑 */
+  
+  /* 카드 하단 액션 버튼들 */
+  .card-actions {
+    margin-top: 1.25rem;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 0.5rem;
+  }
+  
+  .btn-action {
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.5rem 0;
+  }
+  
+  .btn-outline-brown {
+    color: #8B4513;
+    border-color: #8B4513;
+  }
+  .btn-outline-brown:hover {
+    background-color: #8B4513;
+    color: #fff;
+  }
+  
+  /* 비행 준비 완료 섹션 */
+  .ready-header-box {
+    background-color: #f1f8e9;
+    border: 1px solid #dcedc8;
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+  }
+  
+  /* 토스트 메시지 (GiftElf와 동일) */
+  .toast-custom {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    max-width: 300px;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.9rem;
+    background: #333;
+    color: #fff;
+    z-index: 1050;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    transition: opacity 0.3s;
+    opacity: 0;
+  }
+  .toast-custom.show { opacity: 1; }
+  .toast-custom.toast-success { background: #2e7d32; }
+  .toast-custom.toast-error { background: #c62828; }
+  .toast-custom.d-none { display: none; }

--- a/frontend/js/reindeer.js
+++ b/frontend/js/reindeer.js
@@ -1,0 +1,385 @@
+const API_BASE = "http://127.0.0.1:8000";
+
+const API = {
+  list: `${API_BASE}/reindeer/`,
+  updateStatus: `${API_BASE}/reindeer/update-status`,
+  logHealth: `${API_BASE}/reindeer/log-health`,
+  getLogs: (id) => `${API_BASE}/reindeer/${id}/health-logs`,
+  available: `${API_BASE}/reindeer/available`,
+};
+
+const state = {
+  reindeers: [],
+  availableReindeers: [],
+  selectedHealthReindeerId: null, // 건강 기록 탭에서 선택된 루돌프
+};
+
+let editModal;
+
+// -------------------- 공통 유틸 --------------------
+
+function $(sel, parent = document) {
+  return parent.querySelector(sel);
+}
+
+function showToast(message, type = "info") {
+  const toast = $("#toast");
+  if (!toast) return;
+
+  toast.textContent = message;
+  toast.classList.remove("d-none", "show", "toast-success", "toast-error");
+  
+  // 리플로우 강제하여 애니메이션 재시작 효과
+  void toast.offsetWidth;
+
+  if (type === "success") toast.classList.add("toast-success");
+  else if (type === "error") toast.classList.add("toast-error");
+  
+  toast.classList.remove("d-none");
+  setTimeout(() => toast.classList.add("show"), 10);
+
+  setTimeout(() => {
+    toast.classList.remove("show");
+    setTimeout(() => toast.classList.add("d-none"), 300);
+  }, 2500);
+}
+
+async function fetchJson(url, options = {}) {
+  const headers = options.headers ? { ...options.headers } : {};
+  if (options.body && !headers["Content-Type"]) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  try {
+    const res = await fetch(url, { ...options, headers });
+    const data = await res.json();
+
+    if (!res.ok) {
+      const msg = data.detail || JSON.stringify(data);
+      throw new Error(msg);
+    }
+    return data;
+  } catch (err) {
+    throw err;
+  }
+}
+
+// -------------------- 초기화 --------------------
+
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  
+  // 모달 인스턴스
+  const modalEl = document.getElementById("editModal");
+  if (modalEl && window.bootstrap) {
+    editModal = new bootstrap.Modal(modalEl);
+  }
+
+  // 버튼 이벤트 리스너
+  $("#btn-submit-edit").addEventListener("click", submitEdit);
+  $("#btn-save-health-log").addEventListener("click", submitHealthLog);
+  $("#health-reindeer-select").addEventListener("change", (e) => {
+    loadHealthLogs(e.target.value);
+  });
+
+  // 초기 데이터 로드
+  loadReindeers();
+});
+
+// -------------------- 탭 전환 --------------------
+
+function initTabs() {
+  const buttons = document.querySelectorAll(".tab-button");
+  const panels = document.querySelectorAll(".tab-panel");
+
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const targetId = btn.dataset.tabTarget;
+
+      buttons.forEach((b) => b.classList.remove("active"));
+      panels.forEach((p) => p.classList.remove("active"));
+
+      btn.classList.add("active");
+      const panel = document.querySelector(`#tab-${targetId}`);
+      if (panel) panel.classList.add("active");
+
+      // 탭 전환 시 데이터 리프레시
+      if (targetId === "status") loadReindeers();
+      if (targetId === "ready") loadAvailable();
+      if (targetId === "health") loadReindeers().then(renderSelectOptions); 
+    });
+  });
+}
+
+// -------------------- 1. 루돌프 상태 관리 --------------------
+
+async function loadReindeers() {
+  try {
+    const data = await fetchJson(API.list);
+    state.reindeers = data;
+    renderReindeerCards();
+    return data;
+  } catch (err) {
+    console.error(err);
+    showToast("데이터 로드 실패: " + err.message, "error");
+  }
+}
+
+function renderReindeerCards() {
+  const container = $("#reindeer-list-container");
+  container.innerHTML = "";
+
+  state.reindeers.forEach((r) => {
+    const col = document.createElement("div");
+    col.className = "col-md-6 col-lg-4";
+
+    let badgeClass = "status-READY";
+    let badgeText = "준비완료";
+    if (r.status === "RESTING") { badgeClass = "status-RESTING"; badgeText = "휴식 중"; }
+    else if (r.status === "ONDELIVERY") { badgeClass = "status-ONDELIVERY"; badgeText = "배송 중"; }
+
+    col.innerHTML = `
+      <article class="reindeer-card">
+        <div class="card-header-custom">
+          <div class="reindeer-name">🦌 ${r.name}</div>
+          <span class="status-badge ${badgeClass}">${badgeText}</span>
+        </div>
+        
+        <div class="stat-row">
+          <div class="stat-label">
+            <span>❤️ 체력</span>
+            <span>${r.current_stamina} / 100</span>
+          </div>
+          <div class="progress-custom">
+            <div class="progress-bar-stamina" style="width: ${r.current_stamina}%; height:100%;"></div>
+          </div>
+        </div>
+
+        <div class="stat-row">
+          <div class="stat-label">
+            <span>⚡ 마법력</span>
+            <span>${r.current_magic} / 100</span>
+          </div>
+          <div class="progress-custom">
+            <div class="progress-bar-magic" style="width: ${r.current_magic}%; height:100%;"></div>
+          </div>
+        </div>
+
+        <div class="card-actions">
+          <button class="btn btn-outline-secondary btn-action btn-edit" data-id="${r.reindeer_id}">⚙ 수정</button>
+          <button class="btn btn-outline-brown btn-action btn-carrot" data-id="${r.reindeer_id}">🥕 당근</button>
+          <button class="btn btn-outline-brown btn-action btn-magic" data-id="${r.reindeer_id}">💎 마석</button>
+        </div>
+      </article>
+    `;
+
+    // 이벤트 연결
+    col.querySelector(".btn-edit").addEventListener("click", () => openEditModal(r.reindeer_id));
+    col.querySelector(".btn-carrot").addEventListener("click", () => giveItem(r.reindeer_id, "carrot"));
+    col.querySelector(".btn-magic").addEventListener("click", () => giveItem(r.reindeer_id, "magic"));
+
+    container.appendChild(col);
+  });
+}
+
+// 🥕 & 💎 아이템 주기 로직 (프론트 계산 후 API 호출)
+async function giveItem(id, type) {
+  const target = state.reindeers.find(r => r.reindeer_id === id);
+  if (!target) return;
+
+  let newStamina = target.current_stamina;
+  let newMagic = target.current_magic;
+  const newStatus = "RESTING"; // 무조건 휴식으로 변경
+
+  if (type === "carrot") {
+    newStamina = Math.min(newStamina + 10, 100);
+  } else if (type === "magic") {
+    newMagic = Math.min(newMagic + 10, 100);
+  }
+
+  const payload = {
+    reindeer_id: id,
+    status: newStatus,
+    current_stamina: newStamina,
+    current_magic: newMagic
+  };
+
+  try {
+    await fetchJson(API.updateStatus, {
+      method: "POST",
+      body: JSON.stringify(payload)
+    });
+    
+    showToast(type === "carrot" ? "당근을 주었습니다! (체력 +10)" : "마석을 주었습니다! (마력 +10)", "success");
+    loadReindeers(); // 새로고침
+  } catch (err) {
+    showToast("업데이트 실패: " + err.message, "error");
+  }
+}
+
+// 수정 모달 열기
+function openEditModal(id) {
+  const target = state.reindeers.find(r => r.reindeer_id === id);
+  if (!target) return;
+
+  $("#edit-id").value = id;
+  $("#editModalTitle").innerText = `🦌 ${target.name} 정보 수정`;
+  $("#edit-stamina").value = target.current_stamina;
+  $("#edit-magic").value = target.current_magic;
+  $("#edit-status").value = target.status;
+
+  editModal.show();
+}
+
+// 수정 저장
+async function submitEdit() {
+  const id = parseInt($("#edit-id").value);
+  const stamina = parseInt($("#edit-stamina").value);
+  const magic = parseInt($("#edit-magic").value);
+  const status = $("#edit-status").value;
+
+  if (stamina < 0 || stamina > 100 || magic < 0 || magic > 100) {
+    return showToast("체력과 마력은 0~100 사이여야 합니다.", "error");
+  }
+
+  const payload = {
+    reindeer_id: id,
+    status: status,
+    current_stamina: stamina,
+    current_magic: magic
+  };
+
+  try {
+    await fetchJson(API.updateStatus, {
+      method: "POST",
+      body: JSON.stringify(payload)
+    });
+    showToast("정보가 수정되었습니다.", "success");
+    editModal.hide();
+    loadReindeers();
+  } catch (err) {
+    showToast("수정 실패: " + err.message, "error");
+  }
+}
+
+// -------------------- 2. 건강 기록 관리 --------------------
+
+function renderSelectOptions() {
+  const select = $("#health-reindeer-select");
+  // 기존 옵션 유지 여부는 로직에 따라 결정 (여기선 초기화 후 재생성)
+  const currentVal = select.value; 
+  
+  select.innerHTML = `<option value="" disabled selected>루돌프를 선택하세요</option>`;
+  
+  state.reindeers.forEach(r => {
+    const opt = document.createElement("option");
+    opt.value = r.reindeer_id;
+    opt.textContent = `[${r.reindeer_id}] ${r.name}`;
+    select.appendChild(opt);
+  });
+
+  if(currentVal) select.value = currentVal;
+}
+
+async function loadHealthLogs(reindeerId) {
+  if(!reindeerId) return;
+  state.selectedHealthReindeerId = reindeerId;
+
+  // UI 이름 업데이트
+  const target = state.reindeers.find(r => r.reindeer_id == reindeerId);
+  if(target) $("#health-log-target-name").textContent = `Target: ${target.name}`;
+
+  const tbody = $("#health-log-tbody");
+  tbody.innerHTML = `<tr><td colspan="2" class="text-center py-3">로딩 중...</td></tr>`;
+
+  try {
+    const logs = await fetchJson(API.getLogs(reindeerId)); // GET /reindeer/{id}/health-logs
+    renderHealthLogs(logs);
+  } catch (err) {
+    tbody.innerHTML = `<tr><td colspan="2" class="text-center text-danger py-3">기록을 불러오지 못했습니다.</td></tr>`;
+  }
+}
+
+function renderHealthLogs(logs) {
+  const tbody = $("#health-log-tbody");
+  tbody.innerHTML = "";
+
+  if (!logs || logs.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="2" class="text-center py-3 text-muted">기록이 없습니다.</td></tr>`;
+    return;
+  }
+
+  logs.forEach(log => {
+    const tr = document.createElement("tr");
+    
+    // 날짜 포맷팅
+    let dateStr = log.log_timestamp;
+    try {
+        const d = new Date(log.log_timestamp);
+        dateStr = d.toLocaleDateString("ko-KR") + " " + d.toLocaleTimeString("ko-KR", {hour: '2-digit', minute:'2-digit'});
+    } catch(e) {}
+
+    tr.innerHTML = `
+      <td class="small text-muted">${dateStr}</td>
+      <td>${log.notes}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+async function submitHealthLog() {
+  const id = $("#health-reindeer-select").value;
+  const note = $("#health-note").value;
+
+  if (!id) return showToast("루돌프를 선택해주세요.", "error");
+  if (!note.trim()) return showToast("내용을 입력해주세요.", "error");
+
+  try {
+    await fetchJson(API.logHealth, {
+      method: "POST",
+      body: JSON.stringify({ reindeer_id: id, notes: note })
+    });
+    
+    showToast("건강 기록이 추가되었습니다.", "success");
+    $("#health-note").value = "";
+    loadHealthLogs(id); // 목록 갱신
+  } catch (err) {
+    showToast("기록 저장 실패: " + err.message, "error");
+  }
+}
+
+// -------------------- 3. 비행 준비 완료 조회 --------------------
+
+async function loadAvailable() {
+  const tbody = $("#ready-reindeer-tbody");
+  tbody.innerHTML = `<tr><td colspan="4" class="text-center py-3">로딩 중...</td></tr>`;
+
+  try {
+    const data = await fetchJson(API.available);
+    state.availableReindeers = data;
+    renderAvailableTable(data);
+  } catch (err) {
+    tbody.innerHTML = `<tr><td colspan="4" class="text-center text-danger py-3">데이터 로드 실패</td></tr>`;
+  }
+}
+
+function renderAvailableTable(list) {
+  const tbody = $("#ready-reindeer-tbody");
+  tbody.innerHTML = "";
+
+  if (!list.length) {
+    tbody.innerHTML = `<tr><td colspan="4" class="text-center py-4 text-muted">비행 가능한 루돌프가 없습니다.<br><small>(체력 70 이상 + 준비완료 상태 필요)</small></td></tr>`;
+    return;
+  }
+
+  list.forEach(r => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td class="ps-4 fw-bold">🦌 ${r.name}</td>
+      <td><span class="text-danger fw-bold">${r.current_stamina}</span> / 100</td>
+      <td><span class="text-primary fw-bold">${r.current_magic}</span> / 100</td>
+      <td class="text-end pe-4"><span class="badge bg-success">비행 가능</span></td>
+    `;
+    tbody.appendChild(tr);
+  });
+}

--- a/frontend/reindeer.html
+++ b/frontend/reindeer.html
@@ -1,20 +1,209 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Reindeer Keeper - Status</title>
+  <meta charset="UTF-8" />
+  <title>SCDMS - 루돌프 관리자 스테이션 (Keeper)</title>
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+  />
+
+  <link rel="stylesheet" href="css/reindeer.css" />
 </head>
-
 <body>
+  <header class="app-header navbar navbar-dark px-3">
+    <div class="d-flex align-items-center gap-2">
+      <span class="logo-icon">🦌</span>
+      <span class="navbar-brand mb-0 h1">SCDMS</span>
+    </div>
 
-<div class="container py-4">
-    <h2 class="mb-4">🦌 Reindeer Keeper - 루돌프 관리</h2>
+    <h1 class="h5 mb-0 text-white">루돌프 관리자 스테이션</h1>
 
-    <p class="text-muted">여기에 루돌프 체력/상태 조회 및 업데이트 기능이 들어갈 예정입니다.</p>
-</div>
+    <div class="d-flex align-items-center gap-2">
+      <span class="badge bg-warning text-dark">Keeper</span>
+      <button
+        class="btn btn-outline-light btn-sm"
+        type="button"
+        onclick="window.location.href='login.html'"
+      >
+        로그아웃
+      </button>
+    </div>
+  </header>
 
+  <main class="container my-4">
+    <ul class="nav nav-pills mb-3 tab-bar" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button
+          class="nav-link active tab-button"
+          data-tab-target="status"
+          type="button"
+        >
+          ♡ 루돌프 상태
+        </button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button
+          class="nav-link tab-button"
+          data-tab-target="health"
+          type="button"
+        >
+          📄 건강 기록
+        </button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button
+          class="nav-link tab-button"
+          data-tab-target="ready"
+          type="button"
+        >
+          ⏱ 비행 준비 완료
+        </button>
+      </li>
+    </ul>
+
+    <section id="tab-status" class="tab-panel active">
+      <div class="mb-3">
+        <h2 class="h5 mb-1">루돌프 상태 관리</h2>
+        <p class="text-muted small">
+          전체 루돌프의 상태를 실시간으로 확인하고 관리합니다. (당근/마석 지급 시 자동 휴식 전환)
+        </p>
+      </div>
+
+      <div id="reindeer-list-container" class="row g-3">
+        </div>
+    </section>
+
+    <section id="tab-health" class="tab-panel">
+      <div class="mb-3">
+        <h2 class="h5 mb-1">건강 기록</h2>
+        <p class="text-muted small">
+          루돌프별 건강 상태를 기록하고 조회합니다.
+        </p>
+      </div>
+
+      <div class="row g-4">
+        <div class="col-lg-4">
+          <div class="card shadow-sm border-0">
+            <div class="card-header bg-white border-bottom-0 pt-3 pb-0">
+              <h5 class="h6 fw-bold">+ 새 건강 검진</h5>
+            </div>
+            <div class="card-body">
+              <div class="mb-3">
+                <label class="form-label small fw-bold">루돌프 선택</label>
+                <select class="form-select" id="health-reindeer-select">
+                  <option selected disabled value="">루돌프를 선택하세요</option>
+                  </select>
+              </div>
+              <div class="mb-3">
+                <label class="form-label small fw-bold">건강 메모</label>
+                <textarea class="form-control" id="health-note" rows="5" placeholder="관찰 내용, 상태, 권장사항 기록..."></textarea>
+              </div>
+              <button class="btn btn-primary w-100" id="btn-save-health-log">
+                + 건강 기록 추가
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-8">
+          <div class="card shadow-sm border-0 h-100">
+            <div class="card-header bg-white border-bottom-0 pt-3 pb-0 d-flex justify-content-between align-items-center">
+              <h5 class="h6 fw-bold mb-0">📋 기록 내역</h5>
+              <small class="text-muted" id="health-log-target-name">루돌프를 선택해주세요</small>
+            </div>
+            <div class="card-body p-0">
+              <div class="table-responsive" style="max-height: 400px; overflow-y: auto;">
+                <table class="table table-hover mb-0 align-middle">
+                  <thead class="table-light sticky-top">
+                    <tr>
+                      <th style="width: 25%">날짜</th>
+                      <th>내용</th>
+                    </tr>
+                  </thead>
+                  <tbody id="health-log-tbody">
+                    <tr>
+                      <td colspan="2" class="text-center py-4 text-muted small">
+                        좌측에서 루돌프를 선택하면 기록이 표시됩니다.
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="tab-ready" class="tab-panel">
+      <div class="ready-header-box mb-3">
+        <div class="d-flex align-items-center gap-2 mb-1">
+          <i class="bi bi-check-circle-fill text-success"></i>
+          <h2 class="h5 mb-0 text-success fw-bold">비행 준비 완료</h2>
+        </div>
+        <p class="text-muted small mb-0">
+          체력 ≥ 70이고 준비완료(READY) 상태인 루돌프 목록 (산타가 배송에 사용할 수 있습니다)
+        </p>
+      </div>
+
+      <div class="card shadow-sm border-0">
+        <div class="card-body p-0">
+          <table class="table table-hover align-middle mb-0">
+            <thead class="table-light">
+              <tr>
+                <th class="ps-4">루돌프</th>
+                <th>체력</th>
+                <th>마법력</th>
+                <th class="text-end pe-4">상태</th>
+              </tr>
+            </thead>
+            <tbody id="ready-reindeer-tbody">
+              </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div class="modal fade" id="editModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title fw-bold" id="editModalTitle">정보 수정</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" id="edit-id">
+          <div class="mb-3">
+            <label class="form-label small fw-bold">현재 체력 (0~100)</label>
+            <input type="number" class="form-control" id="edit-stamina" min="0" max="100">
+          </div>
+          <div class="mb-3">
+            <label class="form-label small fw-bold">현재 마력 (0~100)</label>
+            <input type="number" class="form-control" id="edit-magic" min="0" max="100">
+          </div>
+          <div class="mb-3">
+            <label class="form-label small fw-bold">상태</label>
+            <select class="form-select" id="edit-status">
+              <option value="READY">준비완료 (READY)</option>
+              <option value="RESTING">휴식 중 (RESTING)</option>
+              <option value="ONDELIVERY">배송 중 (ONDELIVERY)</option>
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">취소</button>
+          <button type="button" class="btn btn-primary btn-sm" id="btn-submit-edit">저장</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="toast" class="toast-custom d-none"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/reindeer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 개요

Keeper 역할이 사용하는 **루돌프 관리 페이지(reindeer.html)** 를 추가하고,
기존에 구현된 `/reindeer` 관련 API들과 연동하여 루돌프 상태 관리/건강 기록/비행 준비 목록을 한 화면에서 확인·수정할 수 있도록 UI를 구현했습니다.

## 주요 변경 사항

### 1. 루돌프 상태 탭

- `frontend/reindeer.html`
  - 상단 네비게이션(로고, "루돌프 관리자 스테이션", Keeper 뱃지, 로그아웃 버튼) 추가
  - 탭 3개 구성: **루돌프 상태 / 건강 기록 / 비행 준비 완료**
  - 루돌프 상태 탭에 카드 리스트 영역(`div#reindeerCards`) 추가

- `frontend/js/reindeer.js`
  - `GET /reindeer/` 호출 후 각 루돌프 카드를 렌더링
    - 이름, 상태 뱃지, 체력/마법력 Progress Bar, 현재 값(예: `95 / 100`) 표시
  - 카드 버튼 3개 동작 구현
    - **상태 수정하기**
      - 모달 오픈 → 체력/마력/상태(READY/RESTING/ONDELIVERY) 수정 가능
      - 저장 시 `POST /reindeer/update-status` 호출
    - **당근 주기**
      - 프론트에서 `new_stamina = min(current_stamina + 10, 100)` 계산
      - 상태를 `"RESTING"` 으로 변경
      - `POST /reindeer/update-status` 호출 후 카드 갱신
    - **마석 주기**
      - 프론트에서 `new_magic = min(current_magic + 10, 100)` 계산
      - 상태를 `"RESTING"` 으로 변경
      - `POST /reindeer/update-status` 호출 후 카드 갱신

- `frontend/css/reindeer.css`
  - 갈색 계열 톤, pill 형태 탭, 카드 그림자 등 시안과 유사한 스타일 정의
  - 상태별 뱃지 색상(READY/RESTING/ONDELIVERY) 및 Progress Bar 스타일 적용

### 2. 건강 기록 탭

- 좌측 "새 건강 검진" 카드
  - 루돌프 선택 select 박스 (현재 등록된 루돌프 목록으로 옵션 구성)
  - 건강 메모 textarea
  - "건강 기록 추가" 버튼 클릭 시 `POST /reindeer/log-health` 호출

- 우측 "건강 기록 내역" 카드
  - 모든 루돌프의 건강 로그를 날짜 내림차순으로 테이블 렌더링
  - 각 로그는 `GET /reindeer/{reindeer_id}/health-logs` 로 불러온 뒤 통합
  - 스크롤 가능한 영역으로 구현해 최근 기록 2~3개는 바로 보이도록 처리

### 3. 비행 준비 완료 탭

- `GET /reindeer/available` 연동
- 체력 ≥ 70 이고 READY 상태인 루돌프만 테이블로 표시
  - 컬럼: 루돌프 / 체력 Bar / 마법력 Bar / 상태 뱃지
- 하단 안내 문구 추가
  - “산타는 이 필터링된 목록만 볼 수 있습니다! …” 등 산타용 뷰라는 설명 포함

### 4. 공통 UX

- 상태 저장/당근/마석/건강 기록 추가 등 주요 액션마다 Bootstrap Toast로 알림 표시
- API 에러 발생 시에도 raw JSON 대신 사용자 친화적인 오류 메시지를 토스트로 표시
- 상태 텍스트(READY → 준비완료, RESTING → 휴식중 등) 한글로 변환해서 노출