### PR TITLE
#ISSUE52 - BUG - 배송 그룹 삭제 기능 오류 해결 (apiDELETE 추)

### DIFF
--- a/frontend/js/santa_api.js
+++ b/frontend/js/santa_api.js
@@ -34,3 +34,23 @@ async function apiPOST(path, body = {}) {
     }
     return res.json();
 }
+
+async function apiDELETE(path) {
+    const res = await fetch(API_BASE + path, {
+        method: "DELETE",
+    });
+
+    // 204 No Content → JSON 없음 → 바로 성공 처리
+    if (res.status === 204) {
+        return true;
+    }
+
+    // 에러 처리
+    if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `DELETE ${path} failed (${res.status})`);
+    }
+
+    // (204가 아닌 경우에 대비)
+    return res.json();
+}


### PR DESCRIPTION
이번 PR은 **배송 그룹 삭제 기능이 동작하지 않던 문제를 해결**하고,  
API 호출 유틸(santa_api.js)에 DELETE 요청을 정식으로 추가하여  
전체 Santa Dashboard 기능과 API 흐름을 안정화하는 패치입니다.

---

# 문제 원인

## 1) `apiDELETE()` 함수가 공통 API 유틸에 존재하지 않음
`santa_groups.js`에서는 아래처럼 DELETE 요청을 호출하고 있었음:

```js
await apiDELETE(`/santa/groups/${groupId}`);
```

하지만 `santa_api.js`에는 GET / POST만 존재하고 DELETE 함수가 없어서  
다음 오류가 발생함:

```
ReferenceError: apiDELETE is not defined
```

## 2) FastAPI DELETE 응답이 204 No Content → JSON 파싱 불가

백엔드 엔드포인트:

```python
@router.delete("/santa/groups/{group_id}", status_code=204)
return
```

204는 **body가 존재하면 안 되는 응답 코드**이기 때문에  
프론트에서 `res.json()` 호출 시 다음 오류가 발생함:

```
SyntaxError: Unexpected end of JSON input
```

즉, **DELETE 전용 핸들링이 반드시 필요**한 구조임.

---

#  해결 내용

##  1) `santa_api.js`에 DELETE 함수 신규 추가
204 여부를 체크하여 JSON 파싱 에러를 방지하도록 구현.

```js
async function apiDELETE(path) {
    const res = await fetch(API_BASE + path, {
        method: "DELETE",
    });

    // 204 No Content → JSON 없음 → 성공 처리
    if (res.status === 204) {
        return true;
    }

    if (!res.ok) {
        const text = await res.text();
        throw new Error(text || `DELETE ${path} failed (${res.status})`);
    }

    return res.json();
}
```

## 2) 기존 JS 파일(santa_groups.js)은 문제 없음
- 삭제 버튼 동작 구조 정상
- API 호출 위치·순서 문제 없음
- fetchInitialData() 갱신 정상

→ **수정 필요 없음 (정상)**

---

#  영향도 및 안정성

### 영향받는 범위
- 배송 그룹 삭제 기능 (santa_groups.js)

###  영향받지 않는 범위
- 배송 대상 페이지
- 배송 실행 로직
- 배송 기록 페이지
- 백엔드 로직 전체
- DeliveryLog 스키마 및 다른 API

DELETE 공통 함수 추가는 **하위 호환성 100% 안전한 변경**임.

---

#  테스트 완료 항목

- [x] 삭제 버튼 클릭 → 정상 삭제됨  
- [x] 삭제 후 fetchInitialData() 정상 호출  
- [x] UI 즉시 갱신  
- [x] 204 응답에서 더 이상 JSON 파싱 오류 없음  
- [x] 다른 기능에 부작용 없음  

---
