### PR TITLE
#ISSUE58 - FIX - 산타 페이지 UI/모달/상태 문구 종합 수

### DIFF
--- a/backend/models/region.py
+++ b/backend/models/region.py
@@ -1,14 +1,14 @@
-"""
+'''
 Region Model
 ------------
-아이(Child)가 속한 지역 정보를 관리하는 테이블.
+아이(Child)가 속한 지역 정보를 관리하는 테이블
 
 예시 Seed:
 1: South Korea
 2: North America
 3: Europe
-...
-"""
+등...
+'''
 
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import relationship

--- a/backend/models/rules.py
+++ b/backend/models/rules.py
@@ -1,7 +1,7 @@
 '''
 Rules 모델
 - Child.StatusCode를 수동으로 판단할 때 참고하는 '심사 기준 문구' 저장 테이블
-- 자동 분류 X, 운영 참고용
+- 자동 분류 x, 운영 참고용
 '''
 
 from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey

--- a/backend/routers/list_elf_child.py
+++ b/backend/routers/list_elf_child.py
@@ -114,9 +114,9 @@ def create_child_with_wishlist(payload: ChildCreate, db: Session = Depends(get_d
 # Child 수정 (PATCH)
 @router.patch("/{child_id}", response_model=ChildOut)
 def update_child(child_id: int, payload: ChildUpdate, db: Session = Depends(get_db)):
-    """
+    '''
     Child 기본 정보 수정
-    """
+    '''
 
     child = db.query(Child).filter(Child.ChildID == child_id).first()
     if not child:
@@ -248,9 +248,9 @@ def add_wishlist(child_id: int, payload: WishlistCreate, db: Session = Depends(g
 # Wishlist 수정
 @router.patch("/wishlist/{wishlist_id}", response_model=WishlistItemOut)
 def update_wishlist(wishlist_id: int, payload: WishlistUpdate, db: Session = Depends(get_db)):
-    """
+    '''
     Wishlist 항목 단일 수정
-    """
+    '''
 
     wishlist = db.query(Wishlist).filter(Wishlist.WishlistID == wishlist_id).first()
     if not wishlist:

--- a/backend/utils/seed.py
+++ b/backend/utils/seed.py
@@ -126,13 +126,13 @@ def seed_reindeer():
     
 
 def create_ready_reindeer_view():
-    """비행 가능 후보 루돌프용 DB VIEW 생성"""
+    '''비행 가능 후보 루돌프용 DB VIEW 생성'''
     db = SessionLocal()
     
     # 기존 뷰가 있으면 삭제
     db.execute(text("DROP VIEW IF EXISTS ready_reindeer_view CASCADE;"))
     
-    db.execute(text("""
+    db.execute(text('''
         CREATE OR REPLACE VIEW ready_reindeer_view AS
         SELECT
             reindeer_id,
@@ -143,7 +143,7 @@ def create_ready_reindeer_view():
         FROM reindeer
         WHERE status = 'READY'
           AND current_stamina >= 70;
-    """))
+    '''))
     db.commit()
     db.close()
 
@@ -209,11 +209,11 @@ def seed_staff():
     db.close()
 
 def seed_child():
-    """
+    '''
     Child + Wishlist 더미데이터 자동 생성
     - Name 기준 중복 체크
     - StatusCode / DeliveryStatusCode / ChildNote 값까지 포함
-    """
+    '''
     db = SessionLocal()
 
     dummy_children = [
@@ -294,7 +294,7 @@ def seed_child():
 
 # 지역(Region) 기본값 Seed
 def seed_regions():
-    """
+    '''
     Region 초기 데이터 삽입
     - 1: South Korea
     - 2: North America
@@ -303,7 +303,7 @@ def seed_regions():
     - 5: South America
     - 6: Africa
     - 7: Oceania
-    """
+    '''
     db = SessionLocal()
 
     default_regions = [

--- a/frontend/js/gift_elf.js
+++ b/frontend/js/gift_elf.js
@@ -21,7 +21,7 @@ const state = {
 
 let recipeModal;
 
-// -------------------- 공통 유틸 --------------------
+// -------------------- 공통 util --------------------
 
 function $(sel, parent = document) {
   return parent.querySelector(sel);

--- a/frontend/js/santa_groups.js
+++ b/frontend/js/santa_groups.js
@@ -233,7 +233,7 @@ function renderGroups() {
 
         footer.appendChild(infoText);
         footer.appendChild(btn);
-        footer.appendChild(deleteBtn);  // ★ 여기 추가됨!
+        footer.appendChild(deleteBtn);
 
         card.appendChild(header);
         card.appendChild(footer);


### PR DESCRIPTION
## Summary
산타 페이지 전반에서 발견된 UI 및 기능 오류 4가지를 한 번에 수정한 PR입니다.
배송 상태 뱃지, 아이 상세 모달, 배송 상태 문구, 배송 실패 로그 표시 기능 추가(이 기능은 아직 완벽x)을 통합적으로 개선했습니다.

---

## 주요 수정 사항

### 1) SUCCESS / FAILED 뱃지 색상 통일
- 디자인 가이드에 맞춰 badge-success / badge-failed 리디자인
- 모든 산타 UI에서 일관된 상태 색상 유지

### 2) 산타 아이 상세 모달 미출력 오류 해결
- 렌더링 후 이벤트 바인딩 문제가 원인이었음
- 이벤트 델리게이션 방식으로 전환하여 모달 정상 동작 보장
- overlay hidden 제어 문제 수정

### 3) “배송 준비 중” 문구를 “배송 완료”로 수정
- DONE / Delivered 상태와 통일되게 표시
- Target, Group 페이지 전반에서 문구 일관성 확보

### 4) 배송 실패 기록 표시 기능 추가 -> 완벽하게 작동x 새 이슈 열어서 수정 예정
- Delivery_Log에는 성공만 기록됨 -> 실패 그룹(fetch) 기반으로 직접 변환
- 실패 그룹(failedDetails)을 실패 로그 객체로 변환하여 테이블에 출력
- SUCCESS + FAILED 로그 통합 렌더링(renderAllLogs) 구현
- FAILED 항목은 빨간 뱃지로 구분하여 표시

---